### PR TITLE
0.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-lambda-4dn==0.12.0
-Benchmark-4dn==0.5.2
+Benchmark-4dn==0.5.3
 botocore==1.10.42
 boto3==1.7.42
 urllib3==1.23

--- a/tests/tibanna/unicorn/check_task_awsem/test_handler.py
+++ b/tests/tibanna/unicorn/check_task_awsem/test_handler.py
@@ -1,6 +1,5 @@
 from tibanna.lambdas import check_task_awsem as service
 from tibanna.exceptions import EC2StartingException, StillRunningException
-from tests.tibanna.unicorn.conftest import valid_env
 import pytest
 import boto3
 import random

--- a/tests/tibanna/unicorn/check_task_awsem/test_handler.py
+++ b/tests/tibanna/unicorn/check_task_awsem/test_handler.py
@@ -21,7 +21,6 @@ def s3(check_task_input):
     return boto3.resource('s3').Bucket(bucket_name)
 
 
-@valid_env
 @pytest.mark.webtest
 def test_check_task_awsem_fails_if_no_job_started(check_task_input, s3):
     # ensure there is no job started
@@ -36,7 +35,6 @@ def test_check_task_awsem_fails_if_no_job_started(check_task_input, s3):
     assert 'Failed to find jobid' in str(excinfo.value)
 
 
-@valid_env
 @pytest.mark.webtest
 def test_check_task_awsem_throws_exception_if_not_done(check_task_input):
     with pytest.raises(StillRunningException) as excinfo:
@@ -46,7 +44,6 @@ def test_check_task_awsem_throws_exception_if_not_done(check_task_input):
     assert 'error' not in check_task_input
 
 
-@valid_env
 @pytest.mark.webtest
 def test_check_task_awsem(check_task_input, s3):
     jobid = 'lalala'
@@ -68,7 +65,6 @@ def test_check_task_awsem(check_task_input, s3):
     assert retval == check_task_input_modified
 
 
-@valid_env
 @pytest.mark.webtest
 def test_check_task_awsem_with_long_postrunjson(check_task_input, s3):
     jobid = 'some_uniq_jobid'

--- a/tests/tibanna/unicorn/conftest.py
+++ b/tests/tibanna/unicorn/conftest.py
@@ -8,10 +8,6 @@ def pytest_runtest_setup(item):
     print("Running lambda tests for: ", item)
 
 
-valid_env = pytest.mark.skipif(not os.environ.get("SECRET", False),
-                               reason='Required environment not setup to run test')
-
-
 @pytest.fixture(scope='session')
 def run_task_awsem_event_data():
     return get_event_file_for('run_task_awsem')

--- a/tests/tibanna/unicorn/test_ec2_utils.py
+++ b/tests/tibanna/unicorn/test_ec2_utils.py
@@ -1,72 +1,258 @@
-from tibanna.ec2_utils import update_config, upload_workflow_to_s3
+from tibanna.ec2_utils import (
+    UnicornInput,
+    Args,
+    Config,
+    Execution,
+    upload_workflow_to_s3
+)
 from tibanna.utils import create_jobid
+from tibanna.exceptions import (
+    MissingFieldInInputJsonException
+)
 import boto3
+import pytest
 
 
-def test_update_config(run_task_awsem_event_data):
-    data = run_task_awsem_event_data
-    config = data['config']
-    update_config(config, data['args']['app_name'], data['args']['input_files'], data['args']['input_parameters'])
-    assert config['instance_type'] == 't3.micro'
-    assert config['EBS_optimized'] is True
-    assert config['ebs_size'] >= 10
-    assert config['shutdown_min'] == 30  # check the other fields are preserved in the returned config
+def test_args():
+    input_dict = {'args': {'input_files': {}, 'output_S3_bucket': 'somebucket', 'app_name': 'someapp'}}
+    args = Args(**input_dict['args'])
+    args_dict = args.as_dict()
+    assert 'input_files' in args_dict
+    assert 'app_name' in args_dict
+    assert args_dict['app_name'] == 'someapp'
 
+def test_args_missing_field():
+    input_dict = {'args': {'input_files': {}, 'app_name': 'someapp'}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        args = Args(**input_dict['args'])
+    assert ex
+    assert 'output_S3_bucket' in str(ex.value)
 
-def test_update_config2(run_task_awsem_event_data2):
-    data = run_task_awsem_event_data2
-    config = data['config']
-    update_config(config, data['args']['app_name'], data['args']['input_files'], data['args']['input_parameters'])
-    assert config['instance_type'] == 't3.xlarge'
-    assert config['EBS_optimized'] is True
-    assert config['ebs_size'] >= 10
-    assert config['shutdown_min'] == 30  # check the other fields are preserved in the returned config
+def test_config():
+    input_dict = {'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
+    cfg = Config(**input_dict['config'])
+    cfg_dict = cfg.as_dict()
+    assert 'log_bucket' in cfg_dict
+    assert 'shutdown_min' in cfg_dict
+    assert cfg_dict['shutdown_min'] == 30
 
+def test_unicorn_input():
+    input_dict = {'args': {'input_files': {}, 'app_name': 'bwa-mem',
+                           'output_S3_bucket': 'somebucket',
+                           'cwl_main_filename': 'main.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
+    unicorn_input = UnicornInput(input_dict)
+    unicorn_dict = unicorn_input.as_dict()
+    print(unicorn_dict)
+    assert 'args' in unicorn_dict
+    assert 'config' in unicorn_dict
+    assert 'jobid' in unicorn_dict  # should be created
 
-def test_update_config3(run_task_awsem_event_data_chipseq):
-    data = run_task_awsem_event_data_chipseq
-    config = data['config']
-    update_config(config, data['args']['app_name'], data['args']['input_files'], data['args']['input_parameters'])
-    assert config['instance_type'] == 'c5.4xlarge'
-    assert config['EBS_optimized'] is True
-    assert config['ebs_size'] == 87
+def test_unicorn_input2():
+    """instance_type is provided but not app_name, which should be fine.
+    ebs_size is not provided (no benchmarking) so default value (10) is entered
+    language is wdl this time"""
+    input_dict = {'args': {'input_files': {}, 'language': 'wdl',
+                           'output_S3_bucket': 'somebucket',
+                           'wdl_main_filename': 'main.wdl',
+                           'wdl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output', 'instance_type': 't2.nano'}}
+    unicorn_input = UnicornInput(input_dict)
+    unicorn_dict = unicorn_input.as_dict()
+    print(unicorn_dict)
+    assert 'args' in unicorn_dict
+    assert 'config' in unicorn_dict
+    assert 'ebs_size' in unicorn_dict['config']
+    assert unicorn_dict['config']['ebs_size'] == 10
 
+def test_execution_mem_cpu():
+    """mem and cpu are provided but not app_name or instance_type,
+    which should be fine.
+    language is snakemake this time"""
+    input_dict = {'args': {'input_files': {}, 'language': 'snakemake',
+                           'output_S3_bucket': 'somebucket',
+                           'snakemake_main_filename': 'Snakefile',
+                           'snakemake_directory_url': 'someurl',
+                           'command': 'snakemake',
+                           'container_image': 'quay.io/snakemake/snakemake'},
+                  'config': {'log_bucket': 'tibanna-output', 'mem': 1, 'cpu': 1}}
+    execution = Execution(input_dict)
+    unicorn_dict = execution.input_dict
+    print(execution.instance_type_list)
+    assert 'args' in unicorn_dict
+    assert 'config' in unicorn_dict
+    assert 'instance_type' in unicorn_dict['config']
+    assert unicorn_dict['config']['instance_type'] == 't3.micro'
 
-def test_update_config4(run_task_awsem_event_omit_fields):
-    data = run_task_awsem_event_omit_fields
-    config = data['config']
-    update_config(config, data['args'].get('app_name', ''), data['args']['input_files'], {})
-    assert config['instance_type'] == 't3.micro'
-    assert config['EBS_optimized'] is True
-    assert config['ebs_size'] >= 10
-    assert config['shutdown_min'] == "now"
+def test_execution_benchmark():
+    """mem and cpu are provided but not app_name or instance_type,
+    which should be fine.
+    language is snakemake this time"""
+    input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
+                                                          'object_key': 'haha'}},
+                           'output_S3_bucket': 'somebucket',
+                           'app_name': 'md5',
+                           'cwl_main_filename': 'md5.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output'}}
+    execution = Execution(input_dict)
+    unicorn_dict = execution.input_dict
+    print(unicorn_dict)
+    assert 'args' in unicorn_dict
+    assert 'config' in unicorn_dict
+    assert 'instance_type' in unicorn_dict['config']
+    assert unicorn_dict['config']['instance_type'] == 't3.micro'
 
+def test_unicorn_input_missing_field():
+    """app_name that doesn't exist in benchmark, without instance type, mem, cpu info"""
+    input_dict = {'args': {'input_files': {}, 'app_name': 'app_name_not_in_benchmark',
+                           'output_S3_bucket': 'somebucket',
+                           'cwl_main_filename': 'main.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        unicorn_input = UnicornInput(input_dict)
+    assert ex
+    assert 'app_name' in str(ex.value)
 
-def test_update_config5(run_task_awsem_event_omit_fields2):
-    data = run_task_awsem_event_omit_fields2
-    config = data['config']
-    update_config(config, data['args'].get('app_name', ''), data['args']['input_files'], {})
-    assert config['instance_type'] == 't3.micro'
-    assert config['EBS_optimized'] is True
-    assert config['ebs_size'] >= 10
-    assert config['shutdown_min'] == "now"
+def test_unicorn_input_missing_field2():
+    "no app_name without instance type, mem, cpu info"""
+    input_dict = {'args': {'input_files': {},
+                           'output_S3_bucket': 'somebucket',
+                           'cwl_main_filename': 'main.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        unicorn_input = UnicornInput(input_dict)
+    assert ex
+    assert 'app_name' in str(ex.value)
 
+def test_unicorn_input_missing_field3():
+    """cwl_main_filename missing for cwl workflow
+    (language is not specified which means it is cwl)
+    """
+    input_dict = {'args': {'input_files': {}, 'app_name': 'bwa-mem',
+                           'output_S3_bucket': 'somebucket',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        unicorn_input = UnicornInput(input_dict)
+    assert ex
+    assert 'cwl_main_filename' in str(ex.value)
+
+def test_unicorn_input_missing_field4():
+    """neither cwl_directory_url nor cwl_directory_local is provided"""
+    input_dict = {'args': {'input_files': {}, 'app_name': 'app_name_not_in_benchmark',
+                           'output_S3_bucket': 'somebucket',
+                           'cwl_main_filename': 'main.cwl'},
+                  'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        unicorn_input = UnicornInput(input_dict)
+    assert ex
+    assert 'cwl_directory_url' in str(ex.value)
+
+def test_execution_missing_field5():
+    """language is snakemake but command is missing"""
+    input_dict = {'args': {'input_files': {}, 'language': 'snakemake',
+                           'output_S3_bucket': 'somebucket',
+                           'snakemake_main_filename': 'Snakefile',
+                           'snakemake_directory_url': 'someurl',
+                           'container_image': 'quay.io/snakemake/snakemake'},
+                  'config': {'log_bucket': 'tibanna-output', 'mem': 1, 'cpu': 1}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        execution = Execution(input_dict)
+    assert ex
+    assert 'command' in str(ex.value)
+
+def test_execution_missing_field6():
+    """language is shell but container_image is missing"""
+    input_dict = {'args': {'input_files': {}, 'language': 'shell',
+                           'output_S3_bucket': 'somebucket',
+                           'command': 'some command'},
+                  'config': {'log_bucket': 'tibanna-output', 'mem': 1, 'cpu': 1}}
+    with pytest.raises(MissingFieldInInputJsonException) as ex:
+        execution = Execution(input_dict)
+    assert ex
+    assert 'container_image' in str(ex.value)
+
+def test_create_run_json_dict():
+    input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
+                                                          'object_key': 'haha'}},
+                           'output_S3_bucket': 'somebucket',
+                           'app_name': 'md5',
+                           'cwl_main_filename': 'md5.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output'}}
+    execution = Execution(input_dict)
+    runjson = execution.create_run_json_dict()
+    assert runjson
+
+def test_create_userdata():
+    input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
+                                                          'object_key': 'haha'}},
+                           'output_S3_bucket': 'somebucket',
+                           'app_name': 'md5',
+                           'cwl_main_filename': 'md5.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output'},
+                  'jobid': 'myjobid'}
+    execution = Execution(input_dict)
+    userdata = execution.create_userdata()
+    print(userdata)
+    assert userdata
+    assert 'JOBID=myjobid' in userdata
+
+def test_create_userdata_w_profile():
+    input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
+                                                          'object_key': 'haha'}},
+                           'output_S3_bucket': 'somebucket',
+                           'app_name': 'md5',
+                           'cwl_main_filename': 'md5.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': 'tibanna-output'},
+                  'jobid': 'myjobid'}
+    execution = Execution(input_dict)
+    profile = {'access_key': 'haha', 'secret_key': 'lala'}
+    userdata = execution.create_userdata(profile=profile)
+    print(userdata)
+    assert userdata
+    assert '-a haha -s lala' in userdata
+
+def test_upload_run_json():
+    jobid = create_jobid()
+    log_bucket = 'tibanna-output'
+    input_dict = {'args': {'output_S3_bucket': 'somebucket',
+                           'cwl_main_filename': 'md5.cwl',
+                           'cwl_directory_url': 'someurl'},
+                  'config': {'log_bucket': log_bucket, 'mem': 1, 'cpu': 1},
+                  'jobid': jobid}
+    somejson = {'haha': 'lala'}  
+    execution = Execution(input_dict)
+    execution.upload_run_json(somejson)
+    s3 = boto3.client('s3')
+    res = s3.get_object(Bucket=log_bucket, Key=jobid + '.run.json')
+    assert res
+    # clean up afterwards
+    s3.delete_objects(Bucket=log_bucket,
+                      Delete={'Objects': [{'Key': jobid + '.run.json'}]})
 
 def test_upload_workflow_to_s3(run_task_awsem_event_cwl_upload):
     jobid = create_jobid()
-    args = run_task_awsem_event_cwl_upload['args']
-    cfg = run_task_awsem_event_cwl_upload['config']
-    url = upload_workflow_to_s3(args, cfg, jobid)
+    run_task_awsem_event_cwl_upload['jobid'] = jobid
+    log_bucket = run_task_awsem_event_cwl_upload['config']['log_bucket']
+    unicorn_input = UnicornInput(run_task_awsem_event_cwl_upload)
+    upload_workflow_to_s3(unicorn_input)
     s3 = boto3.client('s3')
-    res1 = s3.get_object(Bucket=cfg['log_bucket'], Key=jobid + '.workflow/main.cwl')
-    res2 = s3.get_object(Bucket=cfg['log_bucket'], Key=jobid + '.workflow/child1.cwl')
-    res3 = s3.get_object(Bucket=cfg['log_bucket'], Key=jobid + '.workflow/child2.cwl')
+    res1 = s3.get_object(Bucket=log_bucket, Key=jobid + '.workflow/main.cwl')
+    res2 = s3.get_object(Bucket=log_bucket, Key=jobid + '.workflow/child1.cwl')
+    res3 = s3.get_object(Bucket=log_bucket, Key=jobid + '.workflow/child2.cwl')
     assert res1
     assert res2
     assert res3
-    assert url == 's3://tibanna-output/' + jobid + '.workflow/'
+    assert unicorn_input.args.cwl_directory_url == 's3://tibanna-output/' + jobid + '.workflow/'
     # clean up afterwards
-    s3.delete_objects(Bucket=cfg['log_bucket'],
+    s3.delete_objects(Bucket=log_bucket,
                       Delete={'Objects': [{'Key': jobid + '.workflow/main.cwl'},
                                           {'Key': jobid + '.workflow/child1.cwl'},
                                           {'Key': jobid + '.workflow/child2.cwl'}]})

--- a/tests/tibanna/unicorn/test_ec2_utils.py
+++ b/tests/tibanna/unicorn/test_ec2_utils.py
@@ -13,7 +13,6 @@ from tibanna.exceptions import (
 )
 import boto3
 import pytest
-import mock
 
 
 def fun():
@@ -299,24 +298,6 @@ def test_launch_and_get_instance_id():
     with pytest.raises(Exception) as ex:
         execution.launch_and_get_instance_id()
     assert 'Request would have succeeded, but DryRun flag is set' in str(ex.value)
-
-
-def test_ec2_exception_coordinator():
-    """mock test of ec2 exceptions"""
-    jobid = create_jobid()
-    log_bucket = 'tibanna-output'
-    input_dict = {'args': {'output_S3_bucket': 'somebucket',
-                           'cwl_main_filename': 'md5.cwl',
-                           'cwl_directory_url': 'someurl'},
-                  'config': {'log_bucket': log_bucket, 'instance_type': 'c5.4xlarge',
-                             'spot_instance': True},
-                  'jobid': jobid}
-    execution = Execution(input_dict, dryrun=True)
-    execution.userdata = execution.create_userdata()
-    with mock.patch('tibanna.ec2_utils.Execution.donothing', new=mock.Mock(err=Exception("InstanceLimitExceeded"))):
-        res = execution.donothing()
-    print(res)
-    assert res == 'haha'
 
 
 def test_ec2_exception_coordinator2():

--- a/tests/tibanna/unicorn/test_ec2_utils.py
+++ b/tests/tibanna/unicorn/test_ec2_utils.py
@@ -15,8 +15,10 @@ import boto3
 import pytest
 import mock
 
+
 def fun():
     raise Exception("InstanceLimitExceeded")
+
 
 def test_args():
     input_dict = {'args': {'input_files': {}, 'output_S3_bucket': 'somebucket', 'app_name': 'someapp'}}
@@ -26,12 +28,14 @@ def test_args():
     assert 'app_name' in args_dict
     assert args_dict['app_name'] == 'someapp'
 
+
 def test_args_missing_field():
     input_dict = {'args': {'input_files': {}, 'app_name': 'someapp'}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        args = Args(**input_dict['args'])
+        Args(**input_dict['args'])
     assert ex
     assert 'output_S3_bucket' in str(ex.value)
+
 
 def test_config():
     input_dict = {'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
@@ -40,6 +44,7 @@ def test_config():
     assert 'log_bucket' in cfg_dict
     assert 'shutdown_min' in cfg_dict
     assert cfg_dict['shutdown_min'] == 30
+
 
 def test_unicorn_input():
     input_dict = {'args': {'input_files': {}, 'app_name': 'bwa-mem',
@@ -53,6 +58,7 @@ def test_unicorn_input():
     assert 'args' in unicorn_dict
     assert 'config' in unicorn_dict
     assert 'jobid' in unicorn_dict  # should be created
+
 
 def test_unicorn_input2():
     """instance_type is provided but not app_name, which should be fine.
@@ -73,6 +79,7 @@ def test_unicorn_input2():
     assert 'ebs_size' in unicorn_dict['config']
     assert unicorn_dict['config']['ebs_size'] == 10
 
+
 def test_execution_mem_cpu():
     """mem and cpu are provided but not app_name or instance_type,
     which should be fine.
@@ -91,6 +98,7 @@ def test_execution_mem_cpu():
     assert 'config' in unicorn_dict
     assert 'instance_type' in unicorn_dict['config']
     assert unicorn_dict['config']['instance_type'] == 't3.micro'
+
 
 def test_execution_benchmark():
     """mem and cpu are provided but not app_name or instance_type,
@@ -111,6 +119,7 @@ def test_execution_benchmark():
     assert 'instance_type' in unicorn_dict['config']
     assert unicorn_dict['config']['instance_type'] == 't3.micro'
 
+
 def test_unicorn_input_missing_field():
     """app_name that doesn't exist in benchmark, without instance type, mem, cpu info"""
     input_dict = {'args': {'input_files': {}, 'app_name': 'app_name_not_in_benchmark',
@@ -119,9 +128,10 @@ def test_unicorn_input_missing_field():
                            'cwl_directory_url': 'someurl'},
                   'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        unicorn_input = UnicornInput(input_dict)
+        UnicornInput(input_dict)
     assert ex
     assert 'app_name' in str(ex.value)
+
 
 def test_unicorn_input_missing_field2():
     "no app_name without instance type, mem, cpu info"""
@@ -131,9 +141,10 @@ def test_unicorn_input_missing_field2():
                            'cwl_directory_url': 'someurl'},
                   'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        unicorn_input = UnicornInput(input_dict)
+        UnicornInput(input_dict)
     assert ex
     assert 'app_name' in str(ex.value)
+
 
 def test_unicorn_input_missing_field3():
     """cwl_main_filename missing for cwl workflow
@@ -144,9 +155,10 @@ def test_unicorn_input_missing_field3():
                            'cwl_directory_url': 'someurl'},
                   'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        unicorn_input = UnicornInput(input_dict)
+        UnicornInput(input_dict)
     assert ex
     assert 'cwl_main_filename' in str(ex.value)
+
 
 def test_unicorn_input_missing_field4():
     """neither cwl_directory_url nor cwl_directory_local is provided"""
@@ -155,9 +167,10 @@ def test_unicorn_input_missing_field4():
                            'cwl_main_filename': 'main.cwl'},
                   'config': {'log_bucket': 'tibanna-output', 'shutdown_min': 30}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        unicorn_input = UnicornInput(input_dict)
+        UnicornInput(input_dict)
     assert ex
     assert 'cwl_directory_url' in str(ex.value)
+
 
 def test_execution_missing_field5():
     """language is snakemake but command is missing"""
@@ -168,9 +181,10 @@ def test_execution_missing_field5():
                            'container_image': 'quay.io/snakemake/snakemake'},
                   'config': {'log_bucket': 'tibanna-output', 'mem': 1, 'cpu': 1}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        execution = Execution(input_dict)
+        Execution(input_dict)
     assert ex
     assert 'command' in str(ex.value)
+
 
 def test_execution_missing_field6():
     """language is shell but container_image is missing"""
@@ -179,9 +193,10 @@ def test_execution_missing_field6():
                            'command': 'some command'},
                   'config': {'log_bucket': 'tibanna-output', 'mem': 1, 'cpu': 1}}
     with pytest.raises(MissingFieldInInputJsonException) as ex:
-        execution = Execution(input_dict)
+        Execution(input_dict)
     assert ex
     assert 'container_image' in str(ex.value)
+
 
 def test_create_run_json_dict():
     input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
@@ -194,6 +209,7 @@ def test_create_run_json_dict():
     execution = Execution(input_dict)
     runjson = execution.create_run_json_dict()
     assert runjson
+
 
 def test_create_userdata():
     input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
@@ -209,6 +225,7 @@ def test_create_userdata():
     print(userdata)
     assert userdata
     assert 'JOBID=myjobid' in userdata
+
 
 def test_create_userdata_w_profile():
     input_dict = {'args': {'input_files': {'input_file': {'bucket_name': 'soos-4dn-bucket',
@@ -226,6 +243,7 @@ def test_create_userdata_w_profile():
     assert userdata
     assert '-a haha -s lala' in userdata
 
+
 def test_upload_run_json():
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -234,7 +252,7 @@ def test_upload_run_json():
                            'cwl_directory_url': 'someurl'},
                   'config': {'log_bucket': log_bucket, 'mem': 1, 'cpu': 1},
                   'jobid': jobid}
-    somejson = {'haha': 'lala'}  
+    somejson = {'haha': 'lala'}
     execution = Execution(input_dict)
     execution.upload_run_json(somejson)
     s3 = boto3.client('s3')
@@ -243,6 +261,7 @@ def test_upload_run_json():
     # clean up afterwards
     s3.delete_objects(Bucket=log_bucket,
                       Delete={'Objects': [{'Key': jobid + '.run.json'}]})
+
 
 def test_launch_args():
     """test creating launch arguments - also test spot_instance"""
@@ -254,7 +273,6 @@ def test_launch_args():
                   'config': {'log_bucket': log_bucket, 'mem': 1, 'cpu': 1,
                              'spot_instance': True},
                   'jobid': jobid}
-    somejson = {'haha': 'lala'}
     execution = Execution(input_dict)
     # userdata is required before launch_args is created
     execution.userdata = execution.create_userdata()
@@ -263,6 +281,7 @@ def test_launch_args():
     assert launch_args
     assert 't3.micro' in str(launch_args)
     assert 'InstanceMarketOptions' in str(launch_args)
+
 
 def test_launch_and_get_instance_id():
     """test dryrun of ec2 launch"""
@@ -274,13 +293,13 @@ def test_launch_and_get_instance_id():
                   'config': {'log_bucket': log_bucket, 'mem': 1, 'cpu': 1,
                              'spot_instance': True},
                   'jobid': jobid}
-    somejson = {'haha': 'lala'}
     execution = Execution(input_dict, dryrun=True)
     # userdata is required before launch_args is created
     execution.userdata = execution.create_userdata()
     with pytest.raises(Exception) as ex:
-        instance_id = execution.launch_and_get_instance_id()
+        execution.launch_and_get_instance_id()
     assert 'Request would have succeeded, but DryRun flag is set' in str(ex.value)
+
 
 def test_ec2_exception_coordinator():
     """mock test of ec2 exceptions"""
@@ -292,7 +311,6 @@ def test_ec2_exception_coordinator():
                   'config': {'log_bucket': log_bucket, 'instance_type': 'c5.4xlarge',
                              'spot_instance': True},
                   'jobid': jobid}
-    somejson = {'haha': 'lala'}
     execution = Execution(input_dict, dryrun=True)
     execution.userdata = execution.create_userdata()
     with mock.patch('tibanna.ec2_utils.Execution.donothing', new=mock.Mock(err=Exception("InstanceLimitExceeded"))):
@@ -300,7 +318,8 @@ def test_ec2_exception_coordinator():
     print(res)
     assert res == 'haha'
 
-def test_ec2_exception_coordinator():
+
+def test_ec2_exception_coordinator2():
     """ec2 limit exceptions with 'fail'"""
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -316,7 +335,8 @@ def test_ec2_exception_coordinator():
         execution.ec2_exception_coordinator(fun)()
     assert exec_info
 
-def test_ec2_exception_coordinator2():
+
+def test_ec2_exception_coordinator3():
     """ec2 exceptions with 'wait_and_retry'"""
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -333,7 +353,8 @@ def test_ec2_exception_coordinator2():
         execution.ec2_exception_coordinator(fun)()
     assert exec_info
 
-def test_ec2_exception_coordinator3():
+
+def test_ec2_exception_coordinator4():
     """ec2 exceptions with 'other_instance_types'"""
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -356,8 +377,9 @@ def test_ec2_exception_coordinator3():
     res = execution.ec2_exception_coordinator(fun)()
     assert res == 'continue'
     assert execution.cfg.instance_type == 't2.small'
-   
-def test_ec2_exception_coordinator4():
+
+
+def test_ec2_exception_coordinator5():
     """ec2 exceptions with 'other_instance_types' but had only one option"""
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -372,10 +394,11 @@ def test_ec2_exception_coordinator4():
     assert execution.cfg.instance_type == 't2.micro'
     execution.userdata = execution.create_userdata()
     with pytest.raises(EC2InstanceLimitException) as exec_info:
-        res = execution.ec2_exception_coordinator(fun)()
+        execution.ec2_exception_coordinator(fun)()
     assert 'No more instance type available' in str(exec_info.value)
- 
-def test_ec2_exception_coordinator5():
+
+
+def test_ec2_exception_coordinator6():
     """ec2 exceptions with 'retry_without_spot'"""
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -390,13 +413,14 @@ def test_ec2_exception_coordinator5():
     execution.userdata = execution.create_userdata()
     res = execution.ec2_exception_coordinator(fun)()
     assert res == 'continue'
-    assert execution.cfg.spot_instance == False  # changed to non-spot 
+    assert execution.cfg.spot_instance is False  # changed to non-spot
     assert execution.cfg.behavior_on_capacity_limit == 'fail'  # changed to non-spot
     with pytest.raises(EC2InstanceLimitException) as exec_info:
         res = execution.ec2_exception_coordinator(fun)()  # this time, it fails
     assert exec_info
 
-def test_ec2_exception_coordinator6():
+
+def test_ec2_exception_coordinator7():
     """ec2 exceptions with 'retry_without_spot' without spot instance"""
     jobid = create_jobid()
     log_bucket = 'tibanna-output'
@@ -407,13 +431,14 @@ def test_ec2_exception_coordinator6():
                              'behavior_on_capacity_limit': 'retry_without_spot'},
                   'jobid': jobid}
     execution = Execution(input_dict, dryrun=True)
-    assert execution.cfg.spot_instance == False
+    assert execution.cfg.spot_instance is False
     execution.userdata = execution.create_userdata()
     with pytest.raises(Exception) as exec_info:
-        res = execution.ec2_exception_coordinator(fun)()
+        execution.ec2_exception_coordinator(fun)()
     assert "'retry_without_spot' works only with 'spot_instance'" in str(exec_info.value)
 
-def test_ec2_exception_coordinator7():
+
+def test_ec2_exception_coordinator8():
     """ec2 exceptions with 'other_instance_types' with both instance_type and mem/cpu
     specified"""
     jobid = create_jobid()
@@ -435,6 +460,7 @@ def test_ec2_exception_coordinator7():
     res = execution.ec2_exception_coordinator(fun)()
     assert res == 'continue'
     assert execution.cfg.instance_type == 't3.small'  # skill t2.micro since it was already tried
+
 
 def test_upload_workflow_to_s3(run_task_awsem_event_cwl_upload):
     jobid = create_jobid()

--- a/tests/tibanna/unicorn/test_ec2_utils.py
+++ b/tests/tibanna/unicorn/test_ec2_utils.py
@@ -57,12 +57,14 @@ def test_unicorn_input():
 def test_unicorn_input2():
     """instance_type is provided but not app_name, which should be fine.
     ebs_size is not provided (no benchmarking) so default value (10) is entered
+    also testing non-conventional fields
     language is wdl this time"""
     input_dict = {'args': {'input_files': {}, 'language': 'wdl',
                            'output_S3_bucket': 'somebucket',
                            'wdl_main_filename': 'main.wdl',
                            'wdl_directory_url': 'someurl'},
-                  'config': {'log_bucket': 'tibanna-output', 'instance_type': 't2.nano'}}
+                  'config': {'log_bucket': 'tibanna-output', 'instance_type': 't2.nano'},
+                  '_tibanna': {}}
     unicorn_input = UnicornInput(input_dict)
     unicorn_dict = unicorn_input.as_dict()
     print(unicorn_dict)

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/tibanna/core.py
+++ b/tibanna/core.py
@@ -142,18 +142,11 @@ class API(object):
         # add jobid
         data['jobid'] = jobid
         if 'args' in data:  # unicorn-only
-            args = data['args']
-            cfg = data['config']
-            if ('cwl_directory_local' in args and args['cwl_directory_local']) or \
-                    ('wdl_directory_local' in args and args['wdl_directory_local']) or \
-                    ('snakemake_directory_local' in args and args['snakemake_directory_local']):
-                url = upload_workflow_to_s3(args, cfg, jobid)
-                if 'language' in args and args['language'] == 'wdl':
-                    args['wdl_directory_url'] = url
-                elif 'language' in args and args['language'] == 'snakemake':
-                    args['snakemake_directory_url'] = url
-                else:
-                    args['cwl_directory_url'] = url
+            unicorn_input = UnicornInput(data)
+            args = unicorn_input.args
+            if args.cwl_directory_local or args.wdl_directory_local or args.snakemake_directory_local:
+                upload_workflow_to_s3(unicorn_input)
+                data['args'] = args.as_dict()  ## update args
         # submit job as an execution
         aws_input = json.dumps(data)
         print("about to start run %s" % run_name)

--- a/tibanna/core.py
+++ b/tibanna/core.py
@@ -35,6 +35,7 @@ from .utils import (
     create_jobid,
 )
 from .ec2_utils import (
+    UnicornInput,
     upload_workflow_to_s3
 )
 # from botocore.errorfactory import ExecutionAlreadyExists
@@ -146,7 +147,7 @@ class API(object):
             args = unicorn_input.args
             if args.cwl_directory_local or args.wdl_directory_local or args.snakemake_directory_local:
                 upload_workflow_to_s3(unicorn_input)
-                data['args'] = args.as_dict()  ## update args
+                data['args'] = args.as_dict()  # update args
         # submit job as an execution
         aws_input = json.dumps(data)
         print("about to start run %s" % run_name)

--- a/tibanna/core.py
+++ b/tibanna/core.py
@@ -145,7 +145,9 @@ class API(object):
         if 'args' in data:  # unicorn-only
             unicorn_input = UnicornInput(data)
             args = unicorn_input.args
-            if args.cwl_directory_local or args.wdl_directory_local or args.snakemake_directory_local:
+            if args.language.startswith('cwl') and args.cwl_directory_local or \
+               args.language == 'wdl' and args.wdl_directory_local or \
+               args.language == 'snakemake' and args.snakemake_directory_local:
                 upload_workflow_to_s3(unicorn_input)
                 data['args'] = args.as_dict()  # update args
         # submit job as an execution

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -29,442 +29,128 @@ from .exceptions import (
 )
 from .nnested_array import flatten, run_on_nested_arrays1
 from Benchmark import run as B
-
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
 NONSPOT_EC2_PARAM_LIST = ['TagSpecifications', 'InstanceInitiatedShutdownBehavior',
                           'MaxCount', 'MinCount', 'DisableApiTermination']
+class Launch(object):
 
-
-def get_start_time():
-    return time.strftime("%Y%m%d-%H:%M:%S-%Z")
-
-
-def create_json_filename(jobid, json_dir):
-    return json_dir + '/' + jobid + '.run.json'
-
-
-def launch_and_get_instance_id(launch_args, jobid, spot_instance=None, spot_duration=None,
-                               behavior_on_capacity_limit='fail'):
-    try:  # capturing stdout from the launch command
-        os.environ['AWS_DEFAULT_REGION'] = AWS_REGION
-        ec2 = boto3.client('ec2')
-    except Exception as e:
-        raise Exception("Failed to create a client for EC2")
-
-    if spot_instance:
-        spot_options = {'SpotInstanceType': 'one-time',
-                        'InstanceInterruptionBehavior': 'terminate'}
-        if spot_duration:
-            spot_options['BlockDurationMinutes'] = spot_duration
-        launch_args.update({'InstanceMarketOptions': {'MarketType': 'spot',
-                                                      'SpotOptions': spot_options}})
-    try:
-        res = 0
-        res = ec2.run_instances(**launch_args)
-    except Exception as e:
-        if 'InsufficientInstanceCapacity' in str(e) or 'InstanceLimitExceeded' in str(e):
-            if behavior_on_capacity_limit == 'fail':
-                errmsg = "Instance limit exception - use 'behavior_on_capacity_limit' option"
-                errmsg += "to change the behavior to wait_and_retry, or retry_without_spot. %s" % str(e)
-                raise EC2InstanceLimitException(errmsg)
-            elif behavior_on_capacity_limit == 'wait_and_retry':
-                errmsg = "Instance limit exception - wait and retry later: %s" % str(e)
-                raise EC2InstanceLimitWaitException(errmsg)
-            elif behavior_on_capacity_limit == 'retry_without_spot':
-                if not spot_instance:
-                    errmsg = "'behavior_on_capacity_limit': 'retry_without_spot' works only with"
-                    errmsg += "'spot_instance' : true. %s" % str(e)
-                    raise Exception(errmsg)
-                del(launch_args['InstanceMarketOptions'])
-                try:
-                    res = ec2.run_instances(**launch_args)
-                    printlog("trying without spot : %s" % str(res))
-                except Exception as e2:
-                    errmsg = "Instance limit exception without spot instance %s" % str(e2)
-                    raise EC2InstanceLimitException(errmsg)
+    def __init__(self, input_dict):
+        if 'jobid' in input_dict and input_dict.get('jobid'):
+            self.jobid = input_dict.get('jobid')
         else:
-            raise Exception("failed to launch instance for job {jobid}: {log}. %s"
-                            .format(jobid=jobid, log=res) % e)
-
-    try:
-        instance_id = res['Instances'][0]['InstanceId']
-    except Exception as e:
-        raise Exception("failed to retrieve instance ID for job {jobid}".format(jobid=jobid))
-
-    return instance_id
-
-
-def read_config(CONFIG_FILE, CONFIG_KEYS):
-
-    # 1. read .workflow.config.json file and get some variables
-    with open(CONFIG_FILE, 'r') as f:
-        cfg = json.load(f)
-
-    # checking all the necessary keys exist
-    for k in CONFIG_KEYS:
-        if k not in cfg:
-            sys.exit("The config file doesn't have key {}".format(k))
-
-    return cfg
+            self.jobid = create_jobid()
+        self.args = input_dict.get('args')
+        self.cfg = input_dict.get('config')
+        self.auto_fill_input_json(self.args, self.cfg)
+        self.user_specified_instance_type = self.cfg.get('instance_type', '')
+        self.user_specified_EBS_optimized = self.cfg.get('EBS_optimized', '')
+        self.benchmark = get_benchmarking()
+        self.init_instance_type_list()
+        self.update_config_instance_type()
 
 
-def create_json_dict(input_dict):
-    # a is the final_args dictionary. json_dir is the output directory for the json file
+    @static
+    def auto_fill_input_json(args, cfg):
+        # args: parameters needed by the instance to run a workflow
+        # cfg: parameters needed to launch an instance
+        if "ebs_size" not in cfg:
+            cfg["ebs_size"] = 0
+        if "ebs_type" not in cfg:
+            cfg['ebs_type'] = 'gp2'
+        if "ebs_iops" not in cfg:
+            cfg['ebs_iops'] = ''
+        if "shutdown_min" not in cfg:
+            cfg['shutdown_min'] = 'now'
+        if 'password' not in cfg:
+            cfg['password'] = ''
+        if 'key_name' not in cfg:
+            cfg['key_name'] = ''
+        cfg['job_tag'] = args.get('app_name', '')
+        cfg['userdata_dir'] = '/tmp/userdata'
+        # local directory in which the json file will be first created.
+        cfg['json_dir'] = '/tmp/json'
+        # postrun json should be made public?
+        if 'public_postrun_json' not in cfg:
+            cfg['public_postrun_json'] = False
+            # 4dn will use 'true' --> this will automatically be added by start_run_awsem
+        # script url
+        cfg['script_url'] = 'https://raw.githubusercontent.com/' + \
+            TIBANNA_REPO_NAME + '/' + TIBANNA_REPO_BRANCH + '/awsf/'
+        # AMI and script directory according to cwl version
+        if 'language' in args and args['language'] == 'wdl':
+            cfg['ami_id'] = AMI_ID_WDL
+        elif 'language' in args and args['language'] == 'shell':
+            cfg['ami_id'] = AMI_ID_SHELL
+        elif 'language' in args and args['language'] == 'snakemake':
+            cfg['ami_id'] = AMI_ID_SNAKEMAKE
+        else:
+            if args['cwl_version'] == 'v1':
+                cfg['ami_id'] = AMI_ID_CWL_V1
+                args['language'] = 'cwl_v1'
+            else:
+                cfg['ami_id'] = AMI_ID_CWL_DRAFT3
+                args['language'] = 'cwl_draft3'
+            if args.get('singularity', False):
+                cfg['singularity'] = True
+        cfg['json_bucket'] = cfg['log_bucket']
+        cfg['language'] = args['language']
 
-    # create jobid here
-    if 'jobid' in input_dict and input_dict.get('jobid'):
-        jobid = input_dict.get('jobid')
-    else:
-        jobid = create_jobid()
+    def init_instance_type_list(self):
+        instance_type = self.user_specified_instance_type
+        mem = self.cfg.get('mem', '')
+        cpu = self.cfg.get('cpu', '')
+        instance_type_dlist = []
+        # user directly specified instance type
+        if instance_type:
+            instance_type_dlist.append(instance_type)
+        # user specified mem and cpu
+        if mem and cpu:
+            list0 = get_instance_types(mem, cpu, exclude_t=False)
+            nonredundant_list = [i for i in list0 if i['instance_type'] != instance_type]
+            instance_type_dlist.extend(nonredundant_list)
+        # user specifically wanted EBS_optimized instances
+        if self.user_specified_EBS_optimized:
+            instance_type_dlist = [i for i in instance_type_dlist if i['EBS_optimized']]
+        # add benchmark only if there is no user specification
+        if len(instance_type_dlist) == 0 and self.benchmark['instance_type']:
+            instance_type_dlist.append(self.benchmark)
+        self.instance_type_list = [i['instance_type'] for i in instance_type_dlist]
+        self.instance_type_info = {i['instance_type']: i for i in instance_type_dlist}
+        self.instance_type_index = 0  # choose the first one initially
 
-    # start time
-    start_time = get_start_time()
+    @property
+    def instance_type(self):
+        if len(self.instance_type_list) > self.instance_type_index:
+            return self.instance_type_list[self.instance_type_index]
+        else:
+            return ''
 
-    a = input_dict.get('args')
-    log_bucket = input_dict.get('config').get('log_bucket')
+    @property
+    def EBS_optimized(self):
+        if self.instance_type:
+            return self.instance_type_info[self.instance_type]['EBS_optimized']
+        else:
+            return ''
 
-    # pre is a dictionary to be printed as a pre-run json file.
-    pre = {'config': input_dict.get('config').copy()}  # copy only config since arg is redundant with 'Job'
-    pre.update({'Job': {'JOBID': jobid,
-                        'App': {
-                                 'App_name': a.get('app_name', ''),
-                                 'App_version': a.get('app_version', ''),
-                                 'language': a.get('language', ''),
-                                 'cwl_url': a.get('cwl_directory_url', ''),
-                                 'main_cwl': a.get('cwl_main_filename', ''),
-                                 'other_cwl_files': ','.join(a.get('cwl_child_filenames', [])),
-                                 'wdl_url': a.get('wdl_directory_url', ''),
-                                 'main_wdl': a.get('wdl_main_filename', ''),
-                                 'other_wdl_files': ','.join(a.get('wdl_child_filenames', [])),
-                                 'snakemake_url': a.get('snakemake_directory_url', ''),
-                                 'main_snakemake': a.get('snakemake_main_filename', ''),
-                                 'other_snakemake_files': ','.join(a.get('snakemake_child_filenames', [])),
-                                 'command': a.get('command', ''),
-                                 'container_image': a.get('container_image', '')
-                        },
-                        'Input': {
-                                 'Input_files_data': {},    # fill in later (below)
-                                 'Secondary_files_data': {},   # fill in later (below)
-                                 'Input_parameters': a.get('input_parameters', {}),
-                                 'Env': a.get('input_env', {})
-                        },
-                        'Output': {
-                                 'output_bucket_directory': a['output_S3_bucket'],
-                                 'output_target': a['output_target'],
-                                 'alt_cond_output_argnames': a.get('alt_cond_output_argnames', []),
-                                 'secondary_output_target': a.get('secondary_output_target', {})
-                        },
-                        'Log': {
-                                 'log_bucket_directory': log_bucket
-                        },
-                        "start_time": start_time
-                        }})
+    def choose_next_instance_type(self):
+        self.instance_type_index += 1
+        if len(self.instance_type_list) <= self.instance_type_index:
+            raise Exception("No more instance type available that matches the criteria")
 
-    # fill in input_files (restructured)
-    for item, value in iter(a['input_files'].items()):
-        pre['Job']['Input']['Input_files_data'][item] = {'class': 'File',
-                                                         'dir': value.get('bucket_name'),
-                                                         'path': value.get('object_key'),
-                                                         'rename': value.get('rename'),
-                                                         'profile': value.get('profile', '')}
-    for item, value in iter(a.get('secondary_files', {}).items()):
-        pre['Job']['Input']['Secondary_files_data'][item] = {'class': 'File',
-                                                             'dir': value.get('bucket_name'),
-                                                             'path': value.get('object_key'),
-                                                             'rename': value.get('rename'),
-                                                             'profile': value.get('profile', '')}
+    def update_config_instance_type(self):
+        # deal with missing fields
+        self.cfg["instance_type"] = self.instance_type
+        if not self.user_specified_EBS_optimized:
+            self.cfg["EBS_optimized"] = self.EBS_optimized
 
-    # remove the password and keyname info
-    if 'password' in pre['config']:
-        del(pre['config']['password'])
-    if 'key_name' in pre['config']:
-        del(pre['config']['key_name'])
-
-    return pre
-
-
-def create_json(input_dict):
-    json_bucket = input_dict.get('config').get('json_bucket')
-    pre = create_json_dict(input_dict)
-    jobid = pre['Job']['JOBID']
-    jsonbody = json.dumps(pre, indent=4, sort_keys=True)
-    jsonkey = jobid + '.run.json'
-
-    # Keep log of the final json
-    logger.info("jsonbody=\n" + jsonbody)
-
-    # copy the json file to the s3 bucket
-    logger.info(json_bucket)
-    logger.info(os.environ)
-
-    if json_bucket:
-        try:
-            s3 = boto3.client('s3')
-        except Exception as e:
-            raise Exception("boto3 client error: Failed to connect to s3 : %s" % str(e))
-        try:
-            res = s3.put_object(Body=jsonbody.encode('utf-8'), Bucket=json_bucket, Key=jsonkey)
-        except Exception:
-            raise Exception("boto3 client error: Failed to upload run.json %s to s3: %s" % (jsonkey, str(res)))
-
-    # print & retur JOBID
-    print("jobid={}".format(jobid))
-    return(jobid)
-
-
-def create_run_workflow(jobid, shutdown_min,
-                        script_url='https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf/',
-                        password='',
-                        json_bucket='4dn-aws-pipeline-run-json',
-                        log_bucket='tibanna-output',
-                        language='cwl_draft3',  # cwl_v1, cwl_draft3
-                        profile=None,
-                        singularity=None):
-    str = ''
-    str += "#!/bin/bash\n"
-    str += "JOBID={}\n".format(jobid)
-    str += "RUN_SCRIPT=aws_run_workflow_generic.sh\n"
-    str += "SHUTDOWN_MIN={}\n".format(shutdown_min)
-    str += "JSON_BUCKET_NAME={}\n".format(json_bucket)
-    str += "LOGBUCKET={}\n".format(log_bucket)
-    str += "SCRIPT_URL={}\n".format(script_url)
-    str += "LANGUAGE={}\n".format(language)
-    str += "wget $SCRIPT_URL/$RUN_SCRIPT\n"
-    str += "chmod +x $RUN_SCRIPT\n"
-    str += "source $RUN_SCRIPT -i $JOBID -m $SHUTDOWN_MIN"
-    str += " -j $JSON_BUCKET_NAME -l $LOGBUCKET -u $SCRIPT_URL -L $LANGUAGE"
-    if password:
-        str += " -p {}".format(password)
-    if profile:
-        str += " -a {access_key} -s {secret_key} -r {region}".format(region=AWS_REGION, **profile)
-    if singularity:
-        str += " -g"
-    str += "\n"
-    print(str)
-    return(str)
-
-
-def create_launch_args(par, jobid, userdata_str):
-    # creating a launch command
-    launch_args = {'ImageId': par['ami_id'],
-                   'InstanceType': par['instance_type'],
-                   'IamInstanceProfile': {'Arn': S3_ACCESS_ARN},
-                   # 'UserData': 'file://' + Userdata_file,
-                   'UserData': userdata_str,
-                   'MaxCount': 1,
-                   'MinCount': 1,
-                   'InstanceInitiatedShutdownBehavior': 'terminate',
-                   'DisableApiTermination': False,
-                   'TagSpecifications': [{'ResourceType': 'instance',
-                                          "Tags": [{"Key": "Name", "Value": "awsem-" + jobid},
-                                                   {"Key": "Type", "Value": "awsem"}]}]
-                   }
-
-    if par['key_name']:
-        launch_args.update({'KeyName': par['key_name']})
-
-    # EBS options
-    if par['EBS_optimized'] is True:
-        launch_args.update({"EbsOptimized": True})
-
-    launch_args.update({"BlockDeviceMappings": [{'DeviceName': '/dev/sdb',
-                                                 'Ebs': {'DeleteOnTermination': True,
-                                                         'VolumeSize': par['ebs_size'],
-                                                         'VolumeType': par['ebs_type']}},
-                                                {'DeviceName': '/dev/sda1',
-                                                 'Ebs': {'DeleteOnTermination': True,
-                                                         'VolumeSize': 8,
-                                                         'VolumeType': 'gp2'}}]})
-    if par['ebs_iops']:    # io1 type, specify iops
-        launch_args["BlockDeviceMappings"][0]["Ebs"]['Iops'] = par['ebs_iops']
-
-    if par['ebs_size'] >= 16000:
-        message = "EBS size limit (16TB) exceeded: (attempted size: %s)" % par['ebs_size']
-        raise EC2LaunchException(message)
-    return launch_args
-
-
-def launch_instance(par, jobid, profile=None):
-    '''profile is a dictionary { access_key: , secret_key: }'''
-    # Create a userdata script to pass to the instance. The userdata script is run_workflow.$JOBID.sh.
-    try:
-        userdata_str = create_run_workflow(jobid, par['shutdown_min'], par['script_url'],
-                                           par['password'], par['json_bucket'], par['log_bucket'],
-                                           par.get('language', 'cwl_draft3'),
-                                           profile,
-                                           par.get('singularity', None))
-    except Exception as e:
-        raise Exception("Cannot create run_workflow script. %s" % e)
-
-    launch_args = create_launch_args(par, jobid, userdata_str)
-    instance_id = launch_and_get_instance_id(launch_args, jobid,
-                                             par.get('spot_instance', None),
-                                             par.get('spot_duration', None),
-                                             par.get('behavior_on_capacity_limit', 'fail'))
-
-    # get public IP for the instance (This may not happen immediately)
-    session = botocore.session.get_session()
-    x = session.create_client('ec2')
-
-    try_again = True
-    while try_again:    # keep trying until you get the result.
-        time.sleep(1)  # wait for one second before trying again.
-        try:
-            # sometimes you don't get a description immediately
-            instance_desc_log = x.describe_instances(InstanceIds=[instance_id])
-            instance_ip = instance_desc_log['Reservations'][0]['Instances'][0]['PublicIpAddress']
-            try_again = False
-        except:
-            try_again = True
-
-    return({'instance_id': instance_id, 'instance_ip': instance_ip, 'start_time': get_start_time()})
-
-
-def create_cloudwatch_dashboard(instance_id, dashboard_name):
-    body = {
-       "widgets": [
-          {
-             "type": "metric",
-             "x": 0,
-             "y": 0,
-             "width": 12,
-             "height": 4,
-             "properties": {
-                "stacked":  True,
-                "metrics": [
-                   [
-                      "System/Linux",
-                      "MemoryUsed",
-                      "InstanceId",
-                      instance_id
-                   ],
-                   [
-                      ".",
-                      "MemoryAvailable",
-                      "InstanceId",
-                      instance_id
-                   ]
-                ],
-                "period": 60,
-                "stat": "Average",
-                "region": AWS_REGION,
-                "title": "Memory Used"
-             }
-          },
-          {
-             "type": "metric",
-             "x": 0,
-             "y": 5,
-             "width": 12,
-             "height": 4,
-             "properties": {
-                "metrics": [
-                   [
-                      "System/Linux",
-                      "DiskSpaceUtilization",
-                      "MountPath",
-                      "/data1",
-                      "InstanceId",
-                      instance_id,
-                      "Filesystem",
-                      "/dev/xvdb"
-                   ],
-                   [
-                      "System/Linux",
-                      "DiskSpaceUtilization",
-                      "MountPath",
-                      "/",
-                      "InstanceId",
-                      instance_id,
-                      "Filesystem",
-                      "/dev/xvda1"
-                   ]
-                ],
-                "period": 60,
-                "stat": "Average",
-                "region": AWS_REGION,
-                "title": "Disk Space Utilization"
-             }
-          },
-          {
-             "type": "metric",
-             "x": 0,
-             "y": 10,
-             "width": 12,
-             "height": 3,
-             "properties": {
-                "metrics": [
-                   [
-                      "System/Linux",
-                      "DiskSpaceUsed",
-                      "MountPath",
-                      "/data1",
-                      "InstanceId",
-                      instance_id,
-                      "Filesystem",
-                      "/dev/xvdb"
-                   ]
-                ],
-                "period": 60,
-                "stat": "Average",
-                "region": AWS_REGION,
-                "title": "Data Disk Space Used"
-             }
-          },
-          {
-             "type": "metric",
-             "x": 0,
-             "y": 13,
-             "width": 12,
-             "height": 3,
-             "properties": {
-                "metrics": [
-                   [
-                      "AWS/EC2",
-                      "CPUUtilization",
-                      "InstanceId",
-                      instance_id
-                   ]
-                ],
-                "period": 60,
-                "stat": "Average",
-                "region": AWS_REGION,
-                "title": "CPU Utilization"
-             }
-          }
-       ]
-    }
-    cw = boto3.client('cloudwatch', AWS_REGION)
-    cw.put_dashboard(
-        DashboardName=dashboard_name,
-        DashboardBody=json.dumps(body)
-    )
-
-
-def update_config(cfg, app_name, input_files, parameters):
-    # deal with missing fields
-    if "instance_type" not in cfg:
-        cfg["instance_type"] = ""
-    if "ebs_size" not in cfg:
-        cfg["ebs_size"] = 0
-    if "EBS_optimized" not in cfg:
-        cfg['EBS_optimized'] = ""
-    if "ebs_type" not in cfg:
-        cfg['ebs_type'] = 'gp2'
-    if "ebs_iops" not in cfg:
-        cfg['ebs_iops'] = ''
-    if "shutdown_min" not in cfg:
-        cfg['shutdown_min'] = 'now'
-    if 'password' not in cfg:
-        cfg['password'] = ''
-    if 'key_name' not in cfg:
-        cfg['key_name'] = ''
-    # add benchmarking result
-    if cfg['instance_type'] != '' and cfg['ebs_size'] != 0 and cfg['EBS_optimized'] != '':
-        pass
-    else:
+    def get_benchmarking(self):
+        """add instance_type, ebs_size, EBS_optimized info based on benchmarking.
+        user-specified values overwrite the benchmarking.
+        """
+        app_name = self.cfg.get('app_name', '')
+        input_files = self.args.get('input_files', {})
+        parameters = self.args.get('parameters')
         input_size_in_bytes = dict()
         for argname, f in iter(input_files.items()):
             bucket = f['bucket_name']
@@ -475,7 +161,6 @@ def update_config(cfg, app_name, input_files, parameters):
             else:
                 size = get_file_size(f['object_key'], bucket)
             input_size_in_bytes.update({str(argname): size})
-
         print({"input_size_in_bytes": input_size_in_bytes})
         if not app_name:
             err_msg = "app_name must be provided to use Benchmarking." + \
@@ -490,105 +175,390 @@ def update_config(cfg, app_name, input_files, parameters):
                 raise Exception("Benchmarking not working. : {}".format(str(res)))
             except:
                 raise Exception("Benchmarking not working. : None")
-
         if res is not None:
             logger.info(str(res))
             instance_type = res['aws']['recommended_instance_type']
             ebs_size = 10 if res['total_size_in_GB'] < 10 else int(res['total_size_in_GB']) + 1
             ebs_opt = res['aws']['EBS_optimized']
+            return {'instance_type: instance_type, 'EBS_optimized': ebs_opt, 'ebs_size': ebs_size}
+        else:
+            return {'instance_type: '', 'EBS_optimized': '', 'ebs_size': 0}
 
-            if cfg['instance_type'] == '':
-                cfg['instance_type'] = instance_type
-            if cfg['ebs_size'] == 0:
-                cfg['ebs_size'] = ebs_size
-            if cfg['EBS_optimized'] == '':
-                cfg['EBS_optimized'] = ebs_opt
+    @static
+    def get_start_time():
+        return time.strftime("%Y%m%d-%H:%M:%S-%Z")
 
-        elif cfg['instance_type'] == '':
-            raise Exception("instance type cannot be determined nor given")
-        elif cfg['ebs_size'] == 0:
-            raise Exception("ebs_size cannot be determined nor given")
-        elif cfg['EBS_optimized'] == '':
-            raise Exception("EBS_optimized cannot be determined nor given")
+    def launch_and_get_instance_id(self)
+        try:  # capturing stdout from the launch command
+            os.environ['AWS_DEFAULT_REGION'] = AWS_REGION
+            ec2 = boto3.client('ec2')
+        except Exception as e:
+            raise Exception("Failed to create a client for EC2")
+        if self.cfg.get('spot_instance', ''):
+            spot_options = {'SpotInstanceType': 'one-time',
+                            'InstanceInterruptionBehavior': 'terminate'}
+            if self.cfg.get('spot_duration, ''):
+                spot_options['BlockDurationMinutes'] = self.cfg.spot_duration
+            self.launch_args.update({'InstanceMarketOptions': {'MarketType': 'spot',
+                                                               'SpotOptions': spot_options}})
+        try:
+            res = 0
+            res = ec2.run_instances(**self.launch_args)
+        except Exception as e:
+            if 'InsufficientInstanceCapacity' in str(e) or 'InstanceLimitExceeded' in str(e):
+                behavior = self.cfg.get('behavior_on_capacity_limit', '')
+                if behavior == 'fail':
+                    errmsg = "Instance limit exception - use 'behavior_on_capacity_limit' option"
+                    errmsg += "to change the behavior to wait_and_retry, or retry_without_spot. %s" % str(e)
+                    raise EC2InstanceLimitException(errmsg)
+                elif behavior == 'wait_and_retry':
+                    errmsg = "Instance limit exception - wait and retry later: %s" % str(e)
+                    raise EC2InstanceLimitWaitException(errmsg)
+                elif behavior == 'retry_without_spot':
+                    if not self.cfg.spot_instance:
+                        errmsg = "'behavior_on_capacity_limit': 'retry_without_spot' works only with"
+                        errmsg += "'spot_instance' : true. %s" % str(e)
+                        raise Exception(errmsg)
+                    del(self.launch_args['InstanceMarketOptions'])
+                    try:
+                        res = ec2.run_instances(**self.launch_args)
+                        printlog("trying without spot : %s" % str(res))
+                    except Exception as e2:
+                        errmsg = "Instance limit exception without spot instance %s" % str(e2)
+                        raise EC2InstanceLimitException(errmsg)
+            else:
+                raise Exception("failed to launch instance for job {jobid}: {log}. %s"
+                                .format(jobid=self.jobid, log=res) % e)
+        try:
+            instance_id = res['Instances'][0]['InstanceId']
+        except Exception as e:
+            raise Exception("failed to retrieve instance ID for job {jobid}".format(jobid=self.jobid))
+        return instance_id
+
+    def create_json_dict(self):
+        # a is the final_args dictionary. json_dir is the output directory for the json file
+        # create jobid here
+        # start time
+        start_time = get_start_time()
+        log_bucket = input_dict.get('config').get('log_bucket')
+        # pre is a dictionary to be printed as a pre-run json file.
+        pre = {'config': input_dict.get('config').copy()}  # copy only config since arg is redundant with 'Job'
+        pre.update({'Job': {'JOBID': jobid,
+                            'App': {
+                                     'App_name': a.get('app_name', ''),
+                                     'App_version': a.get('app_version', ''),
+                                     'language': a.get('language', ''),
+                                     'cwl_url': a.get('cwl_directory_url', ''),
+                                     'main_cwl': a.get('cwl_main_filename', ''),
+                                     'other_cwl_files': ','.join(a.get('cwl_child_filenames', [])),
+                                     'wdl_url': a.get('wdl_directory_url', ''),
+                                     'main_wdl': a.get('wdl_main_filename', ''),
+                                     'other_wdl_files': ','.join(a.get('wdl_child_filenames', [])),
+                                     'snakemake_url': a.get('snakemake_directory_url', ''),
+                                     'main_snakemake': a.get('snakemake_main_filename', ''),
+                                     'other_snakemake_files': ','.join(a.get('snakemake_child_filenames', [])),
+                                     'command': a.get('command', ''),
+                                     'container_image': a.get('container_image', '')
+                            },
+                            'Input': {
+                                     'Input_files_data': {},    # fill in later (below)
+                                     'Secondary_files_data': {},   # fill in later (below)
+                                     'Input_parameters': a.get('input_parameters', {}),
+                                     'Env': a.get('input_env', {})
+                            },
+                            'Output': {
+                                     'output_bucket_directory': a['output_S3_bucket'],
+                                     'output_target': a['output_target'],
+                                     'alt_cond_output_argnames': a.get('alt_cond_output_argnames', []),
+                                     'secondary_output_target': a.get('secondary_output_target', {})
+                            },
+                            'Log': {
+                                     'log_bucket_directory': log_bucket
+                            },
+                            "start_time": start_time
+                            }})
+        # fill in input_files (restructured)
+        for item, value in iter(a['input_files'].items()):
+            pre['Job']['Input']['Input_files_data'][item] = {'class': 'File',
+                                                             'dir': value.get('bucket_name'),
+                                                             'path': value.get('object_key'),
+                                                             'rename': value.get('rename'),
+                                                             'profile': value.get('profile', '')}
+        for item, value in iter(a.get('secondary_files', {}).items()):
+            pre['Job']['Input']['Secondary_files_data'][item] = {'class': 'File',
+                                                                 'dir': value.get('bucket_name'),
+                                                                 'path': value.get('object_key'),
+                                                                 'rename': value.get('rename'),
+                                                                 'profile': value.get('profile', '')}
+        # remove the password and keyname info
+        if 'password' in pre['config']:
+            del(pre['config']['password'])
+        if 'key_name' in pre['config']:
+            del(pre['config']['key_name'])
+        return pre
+
+    def create_json(self):
+        pre = create_json_dict()
+        jsonbody = json.dumps(pre, indent=4, sort_keys=True)
+        jsonkey = self.jobid + '.run.json'
+        # Keep log of the final json
+        logger.info("jsonbody=\n" + jsonbody)
+        # copy the json file to the s3 bucket
+        logger.info("json_bucket = " + self.cfg['json_bucket'])
+        if self.cfg['json_bucket']:
+            try:
+                s3 = boto3.client('s3')
+            except Exception as e:
+                raise Exception("boto3 client error: Failed to connect to s3 : %s" % str(e))
+            try:
+                res = s3.put_object(Body=jsonbody.encode('utf-8'), Bucket=self.cfg['json_bucket'], Key=jsonkey)
+            except Exception:
+                raise Exception("boto3 client error: Failed to upload run.json %s to s3: %s" % (jsonkey, str(res)))
+        # print & retur JOBID
+        print("jobid={}".format(self.jobid))
+        return(self.jobid)
+
+    def create_run_workflow(profile=None):
+        str = ''
+        str += "#!/bin/bash\n"
+        str += "JOBID={}\n".format(self.jobid)
+        str += "RUN_SCRIPT=aws_run_workflow_generic.sh\n"
+        str += "SHUTDOWN_MIN={}\n".format(self.cfg[''shutdown_min'])
+        str += "JSON_BUCKET_NAME={}\n".format(self.cfg['json_bucket'])
+        str += "LOGBUCKET={}\n".format(self.cfg['log_bucket'])
+        str += "SCRIPT_URL={}\n".format(self.cfg['script_url'])
+        str += "LANGUAGE={}\n".format(self.cfg['language'])
+        str += "wget $SCRIPT_URL/$RUN_SCRIPT\n"
+        str += "chmod +x $RUN_SCRIPT\n"
+        str += "source $RUN_SCRIPT -i $JOBID -m $SHUTDOWN_MIN"
+        str += " -j $JSON_BUCKET_NAME -l $LOGBUCKET -u $SCRIPT_URL -L $LANGUAGE"
+        if self.cfg['password']:
+            str += " -p {}".format(self.cfg['password'])
+        if profile:
+            str += " -a {access_key} -s {secret_key} -r {region}".format(region=AWS_REGION, **profile)
+        if self.cfg['singularity']:
+            str += " -g"
+        str += "\n"
+        print(str)
+        return(str)
+
+    def create_launch_args(self):
+        # creating a launch command
+        launch_args = {'ImageId': self.cfg['ami_id'],
+                       'InstanceType': self.cfg['instance_type'],
+                       'IamInstanceProfile': {'Arn': S3_ACCESS_ARN},
+                       'UserData': self.userdata_str,
+                       'MaxCount': 1,
+                       'MinCount': 1,
+                       'InstanceInitiatedShutdownBehavior': 'terminate',
+                       'DisableApiTermination': False,
+                       'TagSpecifications': [{'ResourceType': 'instance',
+                                              "Tags": [{"Key": "Name", "Value": "awsem-" + self.jobid},
+                                                       {"Key": "Type", "Value": "awsem"}]}]
+                       }
+        if self.cfg['key_name']:
+            launch_args.update({'KeyName': self.cfg['key_name']})
+        # EBS options
+        if self.cfg['EBS_optimized'] is True:
+            launch_args.update({"EbsOptimized": True})
+        launch_args.update({"BlockDeviceMappings": [{'DeviceName': '/dev/sdb',
+                                                     'Ebs': {'DeleteOnTermination': True,
+                                                             'VolumeSize': self.cfg['ebs_size'],
+                                                             'VolumeType': self.cfg['ebs_type']}},
+                                                    {'DeviceName': '/dev/sda1',
+                                                     'Ebs': {'DeleteOnTermination': True,
+                                                             'VolumeSize': 8,
+                                                             'VolumeType': 'gp2'}}]})
+        if self.cfg['ebs_iops']:    # io1 type, specify iops
+            launch_args["BlockDeviceMappings"][0]["Ebs"]['Iops'] = self.cfg['ebs_iops']
+        if self.cfg['ebs_size'] >= 16000:
+            message = "EBS size limit (16TB) exceeded: (attempted size: %s)" % self.cfg['ebs_size']
+            raise EC2LaunchException(message)
+        return launch_args
+
+    def launch_instance(self, profile=None):
+        '''profile is a dictionary { access_key: , secret_key: }'''
+        # Create a userdata script to pass to the instance. The userdata script is run_workflow.$JOBID.sh.
+        try:
+            userdata_str = create_run_workflow(self.jobid, self.cfg['shutdown_min'], self.cfg['script_url'],
+                                               self.cfg['password'], self.cfg['json_bucket'], self.cfg['log_bucket'],
+                                               self.cfg.get('language', 'cwl_draft3'),
+                                               profile,
+                                               self.cfg.get('singularity', None))
+        except Exception as e:
+            raise Exception("Cannot create run_workflow script. %s" % e)
+        self.launch_args = self.create_launch_args()
+        instance_id = self.launch_and_get_instance_id()
+        # get public IP for the instance (This may not happen immediately)
+        session = botocore.session.get_session()
+        x = session.create_client('ec2')
+        try_again = True
+        while try_again:    # keep trying until you get the result.
+            time.sleep(1)  # wait for one second before trying again.
+            try:
+                # sometimes you don't get a description immediately
+                instance_desc_log = x.describe_instances(InstanceIds=[instance_id])
+                instance_ip = instance_desc_log['Reservations'][0]['Instances'][0]['PublicIpAddress']
+                try_again = False
+            except:
+                try_again = True
+        return({'instance_id': instance_id, 'instance_ip': instance_ip, 'start_time': get_start_time()})
+
+    def create_cloudwatch_dashboard(instance_id, dashboard_name):
+        body = {
+           "widgets": [
+              {
+                 "type": "metric",
+                 "x": 0,
+                 "y": 0,
+                 "width": 12,
+                 "height": 4,
+                 "properties": {
+                    "stacked":  True,
+                    "metrics": [
+                       [
+                          "System/Linux",
+                          "MemoryUsed",
+                          "InstanceId",
+                          instance_id
+                       ],
+                       [
+                          ".",
+                          "MemoryAvailable",
+                          "InstanceId",
+                          instance_id
+                       ]
+                    ],
+                    "period": 60,
+                    "stat": "Average",
+                    "region": AWS_REGION,
+                    "title": "Memory Used"
+                 }
+              },
+              {
+                 "type": "metric",
+                 "x": 0,
+                 "y": 5,
+                 "width": 12,
+                 "height": 4,
+                 "properties": {
+                    "metrics": [
+                       [
+                          "System/Linux",
+                          "DiskSpaceUtilization",
+                          "MountPath",
+                          "/data1",
+                          "InstanceId",
+                          instance_id,
+                          "Filesystem",
+                          "/dev/xvdb"
+                       ],
+                       [
+                          "System/Linux",
+                          "DiskSpaceUtilization",
+                          "MountPath",
+                          "/",
+                          "InstanceId",
+                          instance_id,
+                          "Filesystem",
+                          "/dev/xvda1"
+                       ]
+                    ],
+                    "period": 60,
+                    "stat": "Average",
+                    "region": AWS_REGION,
+                    "title": "Disk Space Utilization"
+                 }
+              },
+              {
+                 "type": "metric",
+                 "x": 0,
+                 "y": 10,
+                 "width": 12,
+                 "height": 3,
+                 "properties": {
+                    "metrics": [
+                       [
+                          "System/Linux",
+                          "DiskSpaceUsed",
+                          "MountPath",
+                          "/data1",
+                          "InstanceId",
+                          instance_id,
+                          "Filesystem",
+                          "/dev/xvdb"
+                       ]
+                    ],
+                    "period": 60,
+                    "stat": "Average",
+                    "region": AWS_REGION,
+                    "title": "Data Disk Space Used"
+                 }
+              },
+              {
+                 "type": "metric",
+                 "x": 0,
+                 "y": 13,
+                 "width": 12,
+                 "height": 3,
+                 "properties": {
+                    "metrics": [
+                       [
+                          "AWS/EC2",
+                          "CPUUtilization",
+                          "InstanceId",
+                          instance_id
+                       ]
+                    ],
+                    "period": 60,
+                    "stat": "Average",
+                    "region": AWS_REGION,
+                    "title": "CPU Utilization"
+                 }
+              }
+           ]
+        }
+        cw = boto3.client('cloudwatch', AWS_REGION)
+        cw.put_dashboard(
+            DashboardName=dashboard_name,
+            DashboardBody=json.dumps(body)
+        )
+
+    def upload_workflow_to_s3(self):
+        bucket = self.cfg['log_bucket']
+        key_prefix = self.jobid + '.workflow/'
+        language = self.args.get('language', '')
+        if language == 'wdl':
+            main_wf = self.args['wdl_main_filename']
+            wf_files = self.args.get('wdl_child_filenames', [])
+            localdir = self.args['wdl_directory_local']
+        elif language == 'snakemake':
+            main_wf = self.args['snakemake_main_filename']
+            wf_files = self.args.get('snakemake_child_filenames', [])
+            localdir = self.args['snakemake_directory_local']
+        else:
+            main_wf = self.args['cwl_main_filename']
+            wf_files = self.args.get('cwl_child_filenames', [])
+            localdir = self.args['cwl_directory_local']
+        wf_files.append(main_wf)
+        localdir = localdir.rstrip('/')
+        for wf_file in wf_files:
+            source = localdir + '/' + wf_file
+            target = key_prefix + wf_file
+            boto3.client('s3').upload_file(source, bucket, target)
+        return "s3://%s/%s" % (bucket, key_prefix)
 
 
 def get_file_size(key, bucket, size_in_gb=False):
-        '''
-        default returns file size in bytes,
-        unless size_in_gb = True
-        '''
-        meta = does_key_exist(bucket, key)
-        if not meta:
-            raise Exception("key not found: Can't get input file size : %s" % key)
-        one_gb = 1073741824
-        size = meta['ContentLength']
-        if size_in_gb:
-            size = size / one_gb
-        return size
-
-
-def auto_update_input_json(args, cfg):
-    # args: parameters needed by the instance to run a workflow
-    # cfg: parameters needed to launch an instance
-    cfg['job_tag'] = args.get('app_name', '')
-    cfg['userdata_dir'] = '/tmp/userdata'
-
-    # local directory in which the json file will be first created.
-    cfg['json_dir'] = '/tmp/json'
-
-    # postrun json should be made public?
-    if 'public_postrun_json' not in cfg:
-        cfg['public_postrun_json'] = False
-        # 4dn will use 'true' --> this will automatically be added by start_run_awsem
-
-    # script url
-    cfg['script_url'] = 'https://raw.githubusercontent.com/' + \
-        TIBANNA_REPO_NAME + '/' + TIBANNA_REPO_BRANCH + '/awsf/'
-
-    # AMI and script directory according to cwl version
-    if 'language' in args and args['language'] == 'wdl':
-        cfg['ami_id'] = AMI_ID_WDL
-    elif 'language' in args and args['language'] == 'shell':
-        cfg['ami_id'] = AMI_ID_SHELL
-    elif 'language' in args and args['language'] == 'snakemake':
-        cfg['ami_id'] = AMI_ID_SNAKEMAKE
-    else:
-        if args['cwl_version'] == 'v1':
-            cfg['ami_id'] = AMI_ID_CWL_V1
-            args['language'] = 'cwl_v1'
-        else:
-            cfg['ami_id'] = AMI_ID_CWL_DRAFT3
-            args['language'] = 'cwl_draft3'
-        if args.get('singularity', False):
-            cfg['singularity'] = True
-
-    cfg['json_bucket'] = cfg['log_bucket']
-
-    cfg['language'] = args['language']
-    update_config(cfg, args.get('app_name', ''),
-                  args['input_files'], args.get('input_parameters', {}))
-
-
-def upload_workflow_to_s3(args, cfg, jobid):
-    bucket = cfg['log_bucket']
-    key_prefix = jobid + '.workflow/'
-    language = args.get('language', '')
-    if language == 'wdl':
-        main_wf = args['wdl_main_filename']
-        wf_files = args.get('wdl_child_filenames', [])
-        localdir = args['wdl_directory_local']
-    elif language == 'snakemake':
-        main_wf = args['snakemake_main_filename']
-        wf_files = args.get('snakemake_child_filenames', [])
-        localdir = args['snakemake_directory_local']
-    else:
-        main_wf = args['cwl_main_filename']
-        wf_files = args.get('cwl_child_filenames', [])
-        localdir = args['cwl_directory_local']
-    wf_files.append(main_wf)
-    localdir = localdir.rstrip('/')
-    for wf_file in wf_files:
-        source = localdir + '/' + wf_file
-        target = key_prefix + wf_file
-        boto3.client('s3').upload_file(source, bucket, target)
-    return "s3://%s/%s" % (bucket, key_prefix)
+    '''
+    default returns file size in bytes,
+    unless size_in_gb = True
+    '''
+    meta = does_key_exist(bucket, key)
+    if not meta:
+        raise Exception("key not found: Can't get input file size : %s" % key)
+    one_gb = 1073741824
+    size = meta['ContentLength']
+    if size_in_gb:
+        size = size / one_gb
+    return size

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -47,9 +47,9 @@ class UnicornInput(object):
         self.args = Args(**input_dict['args'])  # args is a required field
         self.cfg = Config(**input_dict['config'])  # config is a required field
         # add other fields too
-        for field in input_dict:
+        for field, v in input_dict.items():
             if field not in ['jobid', 'args', 'config']:
-                setattr(self, field)
+                setattr(self, field, v)
         # fill the default values and internally used fields
         self.auto_fill()
 

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -218,6 +218,8 @@ class Config(object):
             self.spot_instance = False
         if not hasattr(self, "behavior_on_capacity_limit"):
             self.behavior_on_capacity_limit = 'fail'
+        if not hasattr(self, 'cloudwatch_dashboard'):
+            self.cloudwatch_dashboard = False
         # postrun json should be made public?
         if not hasattr(self, 'public_postrun_json'):
             self.public_postrun_json = False

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -23,9 +23,12 @@ from .vars import (
     AMI_ID_CWL_DRAFT3
 )
 from .exceptions import (
+    MissingFieldInInputJsonException
     EC2LaunchException,
     EC2InstanceLimitException,
-    EC2InstanceLimitWaitException
+    EC2InstanceLimitWaitException,
+    DependencyStillRunningException,
+    DependencyFailedException
 )
 from .nnested_array import flatten, run_on_nested_arrays1
 from Benchmark import run as B
@@ -33,80 +36,257 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 NONSPOT_EC2_PARAM_LIST = ['TagSpecifications', 'InstanceInitiatedShutdownBehavior',
                           'MaxCount', 'MinCount', 'DisableApiTermination']
-class Launch(object):
 
+
+class Args(object):
+    def __init__(self, **kwargs):
+        for k, v kwargs.items():
+            setattr(self, k, v)
+
+    def update(self, **kwargs):
+        for k, v kwargs.items():
+            setattr(self, k, v)
+
+    def fill_default(self):
+        # if language and cwl_version is not specified,
+        # by default it is cwl_draft3
+        if not hasattr(self, 'language'):
+            if not hasattr(self, 'cwl_version'):
+                self.cwl_version = 'draft3'
+                self.language = 'cwl_draft3'
+            elif self.cwl_version == 'v1':
+                self.language = 'cwl_v1'
+            elif self.cwl_version == 'draft3':
+                self.language = 'cwl_draft3'
+            if not hasattr(self, 'singularity'):
+                self.singularity = False
+        if not hasattr(self, 'app_name'):
+            self.app_name = ''
+        # check workflow info is there and fill in default
+        errmsg_template = "field %s is required in args for language %s"
+        if self.language == 'wdl':
+            if not hasattr(self, 'wdl_main_filename'):
+                raise MissingFieldInInputJsonException(errmsg_template % ('wdl_main_filename', language))
+            if not hasattr(self, 'wdl_child_filenames'):
+                self.wdl_child_filenames = []
+            if not hasattr(self, 'wdl_directory_local'):
+                self.wdl_directory_local = ''
+            if not hasattr(self, 'wdl_directory_url'):
+                self.wdl_directory_url = ''
+            if not self.wdl_directory_local and not self.wdl_directory_url:
+                errmsg = "either %s or %s must be provided in args" % ('wdl_directory_url', 'wdl_directory_local')
+                raise MissingFieldInInputJsonException(errmsg)
+        elif self.language == 'snakemake':
+            if not hasattr(self, 'snakemake_main_filename'):
+                raise MissingFieldInInputJsonException(errmsg_template % ('snakemake_main_filename', language))
+            if not hasattr(self, 'snakemake_child_filenames'):
+                self.snakemake_child_filenames = []
+            if not hasattr(self, 'snakemake_directory_local'):
+                self.snakemake_directory_local = ''
+            if not hasattr(self, 'snakemake_directory_url'):
+                self.snakemake_directory_url = ''
+            if not self.snakemake_directory_local and not self.snakemake_directory_url:
+                errmsg = "either %s or %s must be provided in args" % ('snakemake_directory_url', 'snakemake_directory_local')
+                raise MissingFieldInInputJsonException(errmsg)
+            for field in ['container_image', 'command']:
+                if not hasattr(self, field):
+                    aise MissingFieldInInputJsonException(errmsg_template % (field, language))
+        elif self.language == 'shell':
+            for field in ['container_image', 'command']:
+                if not hasattr(self, field):
+                    aise MissingFieldInInputJsonException(errmsg_template % (field, language))
+        else:
+            if not hasattr(self, 'cwl_main_filename'):
+                raise MissingFieldInInputJsonException(errmsg_template % ('cwl_main_filename', language))
+            if not hasattr(self, 'cwl_child_filenames'):
+                self.cwl_child_filenames = []
+            if not hasattr(self, 'cwl_directory_local'):
+                self.cwl_directory_local = ''
+            if not hasattr(self, 'cwl_directory_url'):
+                self.cwl_directory_url = ''
+            if not self.cwl_directory_local and not self.cwl_directory_url:
+                errmsg = "either %s or %s must be provided in args" % ('cwl_directory_url', 'cwl_directory_local')
+                raise MissingFieldInInputJsonException(errmsg)
+
+    def as_dict(self):
+        return self.__dict__
+
+
+class Config(object):
+    def __init__(self, **kwargs):
+        for k, v kwargs.items():
+            setattr(self, k, v)
+        for field in ['log_bucket']:
+            if not hasattr(self, field):
+                raise MissingFieldInInputJsonException("field %s is required in config" % field)
+
+    def update(self, **kwargs):
+        for k, v kwargs.items():
+            setattr(self, k, v)
+
+    def fill_default(self):
+        # fill in default
+        if not hasattr(self, "instance_type"):
+            cfg.instance_type = ''  # unspecified by default
+        if not hasattr(self, "EBS_optimized"):
+            cfg.EBS_optimized = ''  # unspecified by default
+        if not hasattr(self, "mem"):
+            cfg.mem = 0  # unspecified by default
+        if not hasattr(self, "cpu"):
+            cfg.cpu = ''  # unspecified by default
+        if not hasattr(self, "ebs_size"):
+            cfg.ebs_size = 0  # unspecified by default
+        if not hasattr(self, "ebs_type"):
+            cfg.ebs_type = 'gp2'
+        if not hasattr(self, "ebs_iops"):
+            cfg.ebs_iops = ''
+        if not hasattr(self, "shutdown_min"):
+            cfg.shutdown_min = 'now'
+        if not hasattr(self, 'password'):
+            cfg.password = ''
+        if not hasattr(self, 'key_name'):
+            cfg.key_name = ''
+        # postrun json should be made public?
+        if not hasattr(self, 'public_postrun_json'):
+            cfg.public_postrun_json = False
+            # 4dn will use 'true' --> this will automatically be added by start_run_awsem
+
+    def fill_internal(self):
+        # fill internally-used fields (users cannot specify these fields)
+        # script url
+        cfg.script_url = 'https://raw.githubusercontent.com/' + \
+            TIBANNA_REPO_NAME + '/' + TIBANNA_REPO_BRANCH + '/awsf/'
+        cfg.json_bucket = cfg.log_bucket
+
+    def fill_language_options(self, language='cwl_draft3', singularity=False):
+        """fill in ami_id and language fields (these are also internal)"""
+        if lanauge == 'wdl':
+            cfg.ami_id = AMI_ID_WDL
+        elif language == 'shell':
+            cfg.ami_id = AMI_ID_SHELL
+        elif language == 'snakemake':
+            cfg.ami_id = AMI_ID_SNAKEMAKE
+        else:  # cwl
+            if language in ['cwl', 'cwl_v1']:  # 'cwl' means 'cwl_v1'
+                cfg.ami_id = AMI_ID_CWL_V1
+            else:
+                cfg.ami_id = AMI_ID_CWL_DRAFT3
+            if singularity:  # applied to only cwl though it is pretty useless
+                cfg.singularity = True
+        cfg.language = language
+
+    def fill_other_fields(self, app_name=''):
+        cfg.job_tag = app_name
+
+    def as_dict(self):
+        return self.__dict__
+
+
+class UnicornInput(object):
     def __init__(self, input_dict):
         if 'jobid' in input_dict and input_dict.get('jobid'):
             self.jobid = input_dict.get('jobid')
         else:
             self.jobid = create_jobid()
-        self.args = input_dict.get('args')
-        self.cfg = input_dict.get('config')
-        self.auto_fill_input_json(self.args, self.cfg)
-        self.user_specified_instance_type = self.cfg.get('instance_type', '')
-        self.user_specified_EBS_optimized = self.cfg.get('EBS_optimized', '')
+        self.args = Args(input_dict['args'])  # args is a required field
+        self.cfg = Config(input_dict['config'])  # config is a required field
+        # add other fields too
+        for field in input_dict:
+            if field not in ['jobid', 'args', 'config']:
+                setattr(self, field)
+        # fill the default values and internally used fields
+        auto_fill(self.args, self.cfg)
+
+    def as_dict(self):
+        d = self.__dict__
+        d['args'] = self.args.as_dict()
+        d['config'] = self.cfg.as_dict()
+        return d
+
+    @static
+    def auto_fill(args, cfg):
+        """This function can be called right after initiation (construction)
+        of args and cfg objects
+        """
+        args.fill_default()
+        cfg.fill_default()
+        cfg.fill_internal()
+        cfg.fill_language_options(args.language, args.singularity)
+        cfg.fill_other_fields(args.app_name)
+        # sanity check
+        if args.app_name and args.app_name in B.app_name_function_map:
+            pass  # use benchmarking
+        else:
+            if not cfg.ebs_size:  # unset (set to 0)
+                cfg.ebs_size = 10  # if not set by user or benchmark, just use 10GB as default
+            if not cfg.EBS_optimized:  # either false or unset
+                cfg.EBS_optimized = False  # False by default so t2 instances can be used
+            if cfg.mem and cfg.cpu:
+                pass
+            elif cfg.instance_type:
+                pass
+            else:
+                err_msg = "Not enough fields: app_name must be provided in args to use Benchmarking. " + \
+                          "Without app_name, either mem and cpu or instance_type must be" + \
+                          "in the config field of the execution json, " + \
+                          "preferably along with ebs_size (default 10(GB)) and EBS_optimized (default False)."
+                raise MissingFieldInInputJsonException(err_msg)
+        # add dependency
+        dependency = {}
+        if hasattr(self, 'dependency') and self.dependency:
+            dependency = self.dependency
+        elif hasattr(args, 'dependency') and args.dependency:
+            dependency = args.dependency
+        elif hasattr(cfg, 'dependency') and cfg.dependency:
+            dependency = cfg.dependency
+        if dependency:
+            self.dependency = args.dependency = cfg.dependency = copy.deepcopy(dependency)
+
+
+class Execution(object):
+
+    def __init__(self, input_dict):
+        self.unicorn_input = UnicornInput(input_dict)
+        self.jobid = self.unicorn_input.jobid
+        self.args = self.unicorn_input.args
+        self.cfg = self.unicorn_input.cfg
+        # store user-specified values for instance type, EBS_optimized and ebs_size 
+        # separately, since the values in cfg will change.
+        self.user_specified_instance_type = self.cfg.instance_type
+        self.user_specified_EBS_optimized = self.cfg.EBS_optimized
+        self.user_specified_ebs_size = self.cfg.ebs_size
+        # get benchmark if available
         self.benchmark = get_benchmarking()
         self.init_instance_type_list()
         self.update_config_instance_type()
 
+    @property
+    def input_dict(self):
+        return self.unicorn_input.as_dict()
 
-    @static
-    def auto_fill_input_json(args, cfg):
-        # args: parameters needed by the instance to run a workflow
-        # cfg: parameters needed to launch an instance
-        if "ebs_size" not in cfg:
-            cfg["ebs_size"] = 0
-        if "ebs_type" not in cfg:
-            cfg['ebs_type'] = 'gp2'
-        if "ebs_iops" not in cfg:
-            cfg['ebs_iops'] = ''
-        if "shutdown_min" not in cfg:
-            cfg['shutdown_min'] = 'now'
-        if 'password' not in cfg:
-            cfg['password'] = ''
-        if 'key_name' not in cfg:
-            cfg['key_name'] = ''
-        cfg['job_tag'] = args.get('app_name', '')
-        cfg['userdata_dir'] = '/tmp/userdata'
-        # local directory in which the json file will be first created.
-        cfg['json_dir'] = '/tmp/json'
-        # postrun json should be made public?
-        if 'public_postrun_json' not in cfg:
-            cfg['public_postrun_json'] = False
-            # 4dn will use 'true' --> this will automatically be added by start_run_awsem
-        # script url
-        cfg['script_url'] = 'https://raw.githubusercontent.com/' + \
-            TIBANNA_REPO_NAME + '/' + TIBANNA_REPO_BRANCH + '/awsf/'
-        # AMI and script directory according to cwl version
-        if 'language' in args and args['language'] == 'wdl':
-            cfg['ami_id'] = AMI_ID_WDL
-        elif 'language' in args and args['language'] == 'shell':
-            cfg['ami_id'] = AMI_ID_SHELL
-        elif 'language' in args and args['language'] == 'snakemake':
-            cfg['ami_id'] = AMI_ID_SNAKEMAKE
-        else:
-            if args['cwl_version'] == 'v1':
-                cfg['ami_id'] = AMI_ID_CWL_V1
-                args['language'] = 'cwl_v1'
-            else:
-                cfg['ami_id'] = AMI_ID_CWL_DRAFT3
-                args['language'] = 'cwl_draft3'
-            if args.get('singularity', False):
-                cfg['singularity'] = True
-        cfg['json_bucket'] = cfg['log_bucket']
-        cfg['language'] = args['language']
+    def prelaunch(self, profile=None):
+        check_dependency(**self.args.dependency)
+        runjson = create_run_json_dict(self.args, self.cfg, self.jobid)
+        upload_run_json(runjson, self.jobid, self.cfg.json_bucket)
+        self.userdata = create_userdata(self.jobid, self.cfg, profile=profile)
+
+    def launch(self):
+        self.instance_id = self.launch_and_get_instance_id()
+        self.cfg.update(get_instance_info(self.instance_id))
+
+    def postlaunch(self):
+        if self.cfg.cloudwatch_dashboard:
+            create_cloudwatch_dashboard(self.instance_id, 'awsem-' + self.jobid)
 
     def init_instance_type_list(self):
         instance_type = self.user_specified_instance_type
-        mem = self.cfg.get('mem', '')
-        cpu = self.cfg.get('cpu', '')
         instance_type_dlist = []
         # user directly specified instance type
         if instance_type:
             instance_type_dlist.append(instance_type)
         # user specified mem and cpu
-        if mem and cpu:
-            list0 = get_instance_types(mem, cpu, exclude_t=False)
+        if self.cfg.mem and self.cfg.cpu:
+            list0 = get_instance_types(self.cfg.mem, self.cfg.cpu, exclude_t=False)
             nonredundant_list = [i for i in list0 if i['instance_type'] != instance_type]
             instance_type_dlist.extend(nonredundant_list)
         # user specifically wanted EBS_optimized instances
@@ -117,42 +297,39 @@ class Launch(object):
             instance_type_dlist.append(self.benchmark)
         self.instance_type_list = [i['instance_type'] for i in instance_type_dlist]
         self.instance_type_info = {i['instance_type']: i for i in instance_type_dlist}
-        self.instance_type_index = 0  # choose the first one initially
+        self.current_instance_type_index = 0  # choose the first one initially
 
     @property
-    def instance_type(self):
-        if len(self.instance_type_list) > self.instance_type_index:
-            return self.instance_type_list[self.instance_type_index]
+    def current_instance_type(self):
+        if len(self.instance_type_list) > self.current_instance_type_index:
+            return self.instance_type_list[self.current_instance_type_index]
         else:
             return ''
 
     @property
-    def EBS_optimized(self):
-        if self.instance_type:
-            return self.instance_type_info[self.instance_type]['EBS_optimized']
+    def current_EBS_optimized(self):
+        if self.current_instance_type:
+            return self.instance_type_info[self.current_instance_type]['EBS_optimized']
         else:
             return ''
 
     def choose_next_instance_type(self):
-        self.instance_type_index += 1
-        if len(self.instance_type_list) <= self.instance_type_index:
+        self.current_instance_type_index += 1
+        if len(self.instance_type_list) <= self.current_instance_type_index:
             raise Exception("No more instance type available that matches the criteria")
 
     def update_config_instance_type(self):
         # deal with missing fields
-        self.cfg["instance_type"] = self.instance_type
+        self.cfg.instance_type = self.current_instance_type
         if not self.user_specified_EBS_optimized:
-            self.cfg["EBS_optimized"] = self.EBS_optimized
+            self.cfg.EBS_optimized = self.current_EBS_optimized
 
     def get_benchmarking(self):
         """add instance_type, ebs_size, EBS_optimized info based on benchmarking.
         user-specified values overwrite the benchmarking.
         """
-        app_name = self.cfg.get('app_name', '')
-        input_files = self.args.get('input_files', {})
-        parameters = self.args.get('parameters')
         input_size_in_bytes = dict()
-        for argname, f in iter(input_files.items()):
+        for argname, f in iter(self.args.input_files.items()):
             bucket = f['bucket_name']
             if isinstance(f['object_key'], list):
                 size = flatten(run_on_nested_arrays1(f['object_key'],
@@ -162,13 +339,9 @@ class Launch(object):
                 size = get_file_size(f['object_key'], bucket)
             input_size_in_bytes.update({str(argname): size})
         print({"input_size_in_bytes": input_size_in_bytes})
-        if not app_name:
-            err_msg = "app_name must be provided to use Benchmarking." + \
-                      "Without app_name, instance_type, ebs_size and EBS_optimized must be" + \
-                      "in the config field of the execution json."
-            raise Exception(err_msg)
         try:
-            res = B.benchmark(app_name, {'input_size_in_bytes': input_size_in_bytes, 'parameters': parameters})
+            res = B.benchmark(self.args.app_name, {'input_size_in_bytes': input_size_in_bytes,
+                                                   'parameters': self.args.parameters})
         except:
             try:
                 res
@@ -188,103 +361,104 @@ class Launch(object):
     def get_start_time():
         return time.strftime("%Y%m%d-%H:%M:%S-%Z")
 
-    def launch_and_get_instance_id(self)
+    def launch_and_get_instance_id(self):
         try:  # capturing stdout from the launch command
             os.environ['AWS_DEFAULT_REGION'] = AWS_REGION
             ec2 = boto3.client('ec2')
         except Exception as e:
             raise Exception("Failed to create a client for EC2")
-        if self.cfg.get('spot_instance', ''):
-            spot_options = {'SpotInstanceType': 'one-time',
-                            'InstanceInterruptionBehavior': 'terminate'}
-            if self.cfg.get('spot_duration, ''):
-                spot_options['BlockDurationMinutes'] = self.cfg.spot_duration
-            self.launch_args.update({'InstanceMarketOptions': {'MarketType': 'spot',
-                                                               'SpotOptions': spot_options}})
-        try:
-            res = 0
-            res = ec2.run_instances(**self.launch_args)
-        except Exception as e:
-            if 'InsufficientInstanceCapacity' in str(e) or 'InstanceLimitExceeded' in str(e):
-                behavior = self.cfg.get('behavior_on_capacity_limit', '')
-                if behavior == 'fail':
-                    errmsg = "Instance limit exception - use 'behavior_on_capacity_limit' option"
-                    errmsg += "to change the behavior to wait_and_retry, or retry_without_spot. %s" % str(e)
-                    raise EC2InstanceLimitException(errmsg)
-                elif behavior == 'wait_and_retry':
-                    errmsg = "Instance limit exception - wait and retry later: %s" % str(e)
-                    raise EC2InstanceLimitWaitException(errmsg)
-                elif behavior == 'retry_without_spot':
-                    if not self.cfg.spot_instance:
-                        errmsg = "'behavior_on_capacity_limit': 'retry_without_spot' works only with"
-                        errmsg += "'spot_instance' : true. %s" % str(e)
-                        raise Exception(errmsg)
-                    del(self.launch_args['InstanceMarketOptions'])
-                    try:
-                        res = ec2.run_instances(**self.launch_args)
-                        printlog("trying without spot : %s" % str(res))
-                    except Exception as e2:
-                        errmsg = "Instance limit exception without spot instance %s" % str(e2)
+        while(True):
+            try:
+                res = 0
+                res = ec2.run_instances(**self.launch_args)
+                break
+            except Exception as e:
+                if 'InsufficientInstanceCapacity' in str(e) or 'InstanceLimitExceeded' in str(e):
+                    behavior = self.cfg.behavior_on_capacity_limit
+                    if behavior == 'fail':
+                        errmsg = "Instance limit exception - use 'behavior_on_capacity_limit' option"
+                        errmsg += "to change the behavior to wait_and_retry, or retry_without_spot. %s" % str(e)
                         raise EC2InstanceLimitException(errmsg)
-            else:
-                raise Exception("failed to launch instance for job {jobid}: {log}. %s"
-                                .format(jobid=self.jobid, log=res) % e)
+                    elif behavior == 'wait_and_retry':
+                        errmsg = "Instance limit exception - wait and retry later: %s" % str(e)
+                        raise EC2InstanceLimitWaitException(errmsg)
+                    elif behavior == 'other_instance_types':
+                        try:
+                            self.choose_next_instance_type()
+                        except Exception as e2:
+                            raise EC2InstanceLimitException(str(e2))
+                        self.update_config_instance_type()
+                        continue
+                    elif behavior == 'retry_without_spot':
+                        if not self.cfg.spot_instance:
+                            errmsg = "'behavior_on_capacity_limit': 'retry_without_spot' works only with"
+                            errmsg += "'spot_instance' : true. %s" % str(e)
+                            raise Exception(errmsg)
+                        try:
+                            self.cfg.spot_instance = False
+                            printlog("trying without spot : %s" % str(res))
+                            continue
+                        except Exception as e2:
+                            errmsg = "Instance limit exception without spot instance %s" % str(e2)
+                            raise EC2InstanceLimitException(errmsg)
+                else:
+                    raise Exception("failed to launch instance for job {jobid}: {log}. %s"
+                                    .format(jobid=self.jobid, log=res) % e)
         try:
             instance_id = res['Instances'][0]['InstanceId']
         except Exception as e:
             raise Exception("failed to retrieve instance ID for job {jobid}".format(jobid=self.jobid))
         return instance_id
 
-    def create_json_dict(self):
-        # a is the final_args dictionary. json_dir is the output directory for the json file
+    @static
+    def create_run_json_dict(args, cfg, jobid):
         # create jobid here
         # start time
         start_time = get_start_time()
-        log_bucket = input_dict.get('config').get('log_bucket')
         # pre is a dictionary to be printed as a pre-run json file.
-        pre = {'config': input_dict.get('config').copy()}  # copy only config since arg is redundant with 'Job'
+        pre = {'config': cfg.as_dict()}  # copy only config since arg is redundant with 'Job'
         pre.update({'Job': {'JOBID': jobid,
                             'App': {
-                                     'App_name': a.get('app_name', ''),
-                                     'App_version': a.get('app_version', ''),
-                                     'language': a.get('language', ''),
-                                     'cwl_url': a.get('cwl_directory_url', ''),
-                                     'main_cwl': a.get('cwl_main_filename', ''),
-                                     'other_cwl_files': ','.join(a.get('cwl_child_filenames', [])),
-                                     'wdl_url': a.get('wdl_directory_url', ''),
-                                     'main_wdl': a.get('wdl_main_filename', ''),
-                                     'other_wdl_files': ','.join(a.get('wdl_child_filenames', [])),
-                                     'snakemake_url': a.get('snakemake_directory_url', ''),
-                                     'main_snakemake': a.get('snakemake_main_filename', ''),
-                                     'other_snakemake_files': ','.join(a.get('snakemake_child_filenames', [])),
-                                     'command': a.get('command', ''),
-                                     'container_image': a.get('container_image', '')
+                                     'App_name': args.app_name,
+                                     'App_version': args.app_version,
+                                     'language': args.language,
+                                     'cwl_url': args.cwl_directory_url,
+                                     'main_cwl': args.cwl_main_filename,
+                                     'other_cwl_files': ','.join(args.cwl_child_filenames),
+                                     'wdl_url': args.wdl_directory_url,
+                                     'main_wdl': args.wdl_main_filename,
+                                     'other_wdl_files': ','.join(args.wdl_child_filenames),
+                                     'snakemake_url': args.snakemake_directory_url,
+                                     'main_snakemake': args.snakemake_main_filename,
+                                     'other_snakemake_files': ','.join(args.snakemake_child_filenames),
+                                     'command': args.command,
+                                     'container_image': args.container_image
                             },
                             'Input': {
                                      'Input_files_data': {},    # fill in later (below)
                                      'Secondary_files_data': {},   # fill in later (below)
-                                     'Input_parameters': a.get('input_parameters', {}),
-                                     'Env': a.get('input_env', {})
+                                     'Input_parameters': args.input_parameters,
+                                     'Env': args.input_env
                             },
                             'Output': {
-                                     'output_bucket_directory': a['output_S3_bucket'],
-                                     'output_target': a['output_target'],
-                                     'alt_cond_output_argnames': a.get('alt_cond_output_argnames', []),
-                                     'secondary_output_target': a.get('secondary_output_target', {})
+                                     'output_bucket_directory': args.output_S3_bucket,
+                                     'output_target': args.output_target,
+                                     'alt_cond_output_argnames': args.alt_cond_output_argnames,
+                                     'secondary_output_target': args.secondary_output_target
                             },
                             'Log': {
-                                     'log_bucket_directory': log_bucket
+                                     'log_bucket_directory': cfg.log_bucket
                             },
                             "start_time": start_time
                             }})
         # fill in input_files (restructured)
-        for item, value in iter(a['input_files'].items()):
+        for item, value in iter(args.input_files.items()):
             pre['Job']['Input']['Input_files_data'][item] = {'class': 'File',
                                                              'dir': value.get('bucket_name'),
                                                              'path': value.get('object_key'),
                                                              'rename': value.get('rename'),
                                                              'profile': value.get('profile', '')}
-        for item, value in iter(a.get('secondary_files', {}).items()):
+        for item, value in iter(args.secondary_files.items()):
             pre['Job']['Input']['Secondary_files_data'][item] = {'class': 'File',
                                                                  'dir': value.get('bucket_name'),
                                                                  'path': value.get('object_key'),
@@ -297,113 +471,124 @@ class Launch(object):
             del(pre['config']['key_name'])
         return pre
 
-    def create_json(self):
-        pre = create_json_dict()
-        jsonbody = json.dumps(pre, indent=4, sort_keys=True)
-        jsonkey = self.jobid + '.run.json'
+    @static
+    def upload_run_json(runjson, jobid, json_bucket):
+        jsonbody = json.dumps(runjson, indent=4, sort_keys=True)
+        jsonkey = jobid + '.run.json'
         # Keep log of the final json
         logger.info("jsonbody=\n" + jsonbody)
         # copy the json file to the s3 bucket
-        logger.info("json_bucket = " + self.cfg['json_bucket'])
-        if self.cfg['json_bucket']:
+        logger.info("json_bucket = " + json_bucket)
+        if json_bucket:
             try:
                 s3 = boto3.client('s3')
             except Exception as e:
                 raise Exception("boto3 client error: Failed to connect to s3 : %s" % str(e))
             try:
-                res = s3.put_object(Body=jsonbody.encode('utf-8'), Bucket=self.cfg['json_bucket'], Key=jsonkey)
+                res = s3.put_object(Body=jsonbody.encode('utf-8'), Bucket=json_bucket, Key=jsonkey)
             except Exception:
                 raise Exception("boto3 client error: Failed to upload run.json %s to s3: %s" % (jsonkey, str(res)))
-        # print & retur JOBID
-        print("jobid={}".format(self.jobid))
-        return(self.jobid)
 
-    def create_run_workflow(profile=None):
+    @static
+    def create_userdata(jobid, cfg, profile=None):
+        """Create a userdata script to pass to the instance. The userdata script is run_workflow.$JOBID.sh.
+        profile is a dictionary { access_key: , secret_key: }
+        """
         str = ''
         str += "#!/bin/bash\n"
-        str += "JOBID={}\n".format(self.jobid)
+        str += "JOBID={}\n".format(jobid)
         str += "RUN_SCRIPT=aws_run_workflow_generic.sh\n"
-        str += "SHUTDOWN_MIN={}\n".format(self.cfg[''shutdown_min'])
-        str += "JSON_BUCKET_NAME={}\n".format(self.cfg['json_bucket'])
-        str += "LOGBUCKET={}\n".format(self.cfg['log_bucket'])
-        str += "SCRIPT_URL={}\n".format(self.cfg['script_url'])
-        str += "LANGUAGE={}\n".format(self.cfg['language'])
+        str += "SHUTDOWN_MIN={}\n".format(cfg.shutdown_min)
+        str += "JSON_BUCKET_NAME={}\n".format(cfg.json_bucket)
+        str += "LOGBUCKET={}\n".format(cfg.log_bucket)
+        str += "SCRIPT_URL={}\n".format(cfg.script_url)
+        str += "LANGUAGE={}\n".format(cfg.language)
         str += "wget $SCRIPT_URL/$RUN_SCRIPT\n"
         str += "chmod +x $RUN_SCRIPT\n"
         str += "source $RUN_SCRIPT -i $JOBID -m $SHUTDOWN_MIN"
         str += " -j $JSON_BUCKET_NAME -l $LOGBUCKET -u $SCRIPT_URL -L $LANGUAGE"
-        if self.cfg['password']:
-            str += " -p {}".format(self.cfg['password'])
+        if cfg.password:
+            str += " -p {}".format(cfg.password)
         if profile:
             str += " -a {access_key} -s {secret_key} -r {region}".format(region=AWS_REGION, **profile)
-        if self.cfg['singularity']:
+        if hasattr(cfg, 'singularity') and cfg.singularity:
             str += " -g"
         str += "\n"
         print(str)
         return(str)
 
-    def create_launch_args(self):
+    @property
+    def launch_args(self):
         # creating a launch command
-        launch_args = {'ImageId': self.cfg['ami_id'],
-                       'InstanceType': self.cfg['instance_type'],
-                       'IamInstanceProfile': {'Arn': S3_ACCESS_ARN},
-                       'UserData': self.userdata_str,
-                       'MaxCount': 1,
-                       'MinCount': 1,
-                       'InstanceInitiatedShutdownBehavior': 'terminate',
-                       'DisableApiTermination': False,
-                       'TagSpecifications': [{'ResourceType': 'instance',
-                                              "Tags": [{"Key": "Name", "Value": "awsem-" + self.jobid},
-                                                       {"Key": "Type", "Value": "awsem"}]}]
-                       }
-        if self.cfg['key_name']:
-            launch_args.update({'KeyName': self.cfg['key_name']})
+        largs = {'ImageId': self.cfg.ami_id,
+                 'InstanceType': self.cfg.instance_type,
+                 'IamInstanceProfile': {'Arn': S3_ACCESS_ARN},
+                 'UserData': self.userdata,
+                 'MaxCount': 1,
+                 'MinCount': 1,
+                 'InstanceInitiatedShutdownBehavior': 'terminate',
+                 'DisableApiTermination': False,
+                 'TagSpecifications': [{'ResourceType': 'instance',
+                                        "Tags": [{"Key": "Name", "Value": "awsem-" + self.jobid},
+                                                 {"Key": "Type", "Value": "awsem"}]}]
+                 }
+        if self.cfg.key_name:
+            largs.update({'KeyName': self.cfg.key_name})
         # EBS options
-        if self.cfg['EBS_optimized'] is True:
-            launch_args.update({"EbsOptimized": True})
-        launch_args.update({"BlockDeviceMappings": [{'DeviceName': '/dev/sdb',
-                                                     'Ebs': {'DeleteOnTermination': True,
-                                                             'VolumeSize': self.cfg['ebs_size'],
-                                                             'VolumeType': self.cfg['ebs_type']}},
-                                                    {'DeviceName': '/dev/sda1',
-                                                     'Ebs': {'DeleteOnTermination': True,
-                                                             'VolumeSize': 8,
-                                                             'VolumeType': 'gp2'}}]})
-        if self.cfg['ebs_iops']:    # io1 type, specify iops
-            launch_args["BlockDeviceMappings"][0]["Ebs"]['Iops'] = self.cfg['ebs_iops']
-        if self.cfg['ebs_size'] >= 16000:
-            message = "EBS size limit (16TB) exceeded: (attempted size: %s)" % self.cfg['ebs_size']
+        if self.cfg.EBS_optimized is True:
+            largs.update({"EbsOptimized": True})
+        largs.update({"BlockDeviceMappings": [{'DeviceName': '/dev/sdb',
+                                               'Ebs': {'DeleteOnTermination': True,
+                                                       'VolumeSize': self.cfg.ebs_size,
+                                                       'VolumeType': self.cfg.ebs_type}},
+                                              {'DeviceName': '/dev/sda1',
+                                               'Ebs': {'DeleteOnTermination': True,
+                                                       'VolumeSize': 8,
+                                                       'VolumeType': 'gp2'}}]})
+        if self.cfg.ebs_iops:    # io1 type, specify iops
+            largs["BlockDeviceMappings"][0]["Ebs"]['Iops'] = self.cfg.ebs_iops
+        if self.cfg.ebs_size >= 16000:
+            message = "EBS size limit (16TB) exceeded: (attempted size: %s)" % self.cfg.ebs_size
             raise EC2LaunchException(message)
-        return launch_args
+        if self.cfg.spot_instance:
+            spot_options = {'SpotInstanceType': 'one-time',
+                            'InstanceInterruptionBehavior': 'terminate'}
+            if self.cfg.spot_duration:
+                spot_options['BlockDurationMinutes'] = self.cfg.spot_duration
+            largs.update({'InstanceMarketOptions': {'MarketType': 'spot',
+                                                    'SpotOptions': spot_options}})
+        return largs
 
-    def launch_instance(self, profile=None):
-        '''profile is a dictionary { access_key: , secret_key: }'''
-        # Create a userdata script to pass to the instance. The userdata script is run_workflow.$JOBID.sh.
-        try:
-            userdata_str = create_run_workflow(self.jobid, self.cfg['shutdown_min'], self.cfg['script_url'],
-                                               self.cfg['password'], self.cfg['json_bucket'], self.cfg['log_bucket'],
-                                               self.cfg.get('language', 'cwl_draft3'),
-                                               profile,
-                                               self.cfg.get('singularity', None))
-        except Exception as e:
-            raise Exception("Cannot create run_workflow script. %s" % e)
-        self.launch_args = self.create_launch_args()
-        instance_id = self.launch_and_get_instance_id()
+    @static
+    def get_instance_info(instance_id):
         # get public IP for the instance (This may not happen immediately)
-        session = botocore.session.get_session()
-        x = session.create_client('ec2')
-        try_again = True
-        while try_again:    # keep trying until you get the result.
+        try:
+            ec2 = boto3.client('ec2')
+        except Exception as e:
+            raise Exception("Can't create an ec2 client %s" % str(e))
+        while(True):  # keep trying until you get the result.
             time.sleep(1)  # wait for one second before trying again.
             try:
                 # sometimes you don't get a description immediately
-                instance_desc_log = x.describe_instances(InstanceIds=[instance_id])
+                instance_desc_log = ec2.describe_instances(InstanceIds=[instance_id])
                 instance_ip = instance_desc_log['Reservations'][0]['Instances'][0]['PublicIpAddress']
-                try_again = False
+                break
             except:
-                try_again = True
+                continue
         return({'instance_id': instance_id, 'instance_ip': instance_ip, 'start_time': get_start_time()})
 
+    @static
+    def check_dependency(exec_arn=None):
+        if exec_arn:
+            client = boto3.client('stepfunctions', region_name=AWS_REGION)
+            for arn in exec_arn:
+                res = client.describe_execution(executionArn=arn)
+                if res['status'] == 'RUNNING':
+                    raise DependencyStillRunningException("Dependency is still running: %s" % arn)
+                elif res['status'] == 'FAILED':
+                    raise DependencyFailedException("A Job that this job is dependent on failed: %s" % arn)
+
+    @static
     def create_cloudwatch_dashboard(instance_id, dashboard_name):
         body = {
            "widgets": [
@@ -524,29 +709,43 @@ class Launch(object):
             DashboardBody=json.dumps(body)
         )
 
-    def upload_workflow_to_s3(self):
-        bucket = self.cfg['log_bucket']
-        key_prefix = self.jobid + '.workflow/'
-        language = self.args.get('language', '')
-        if language == 'wdl':
-            main_wf = self.args['wdl_main_filename']
-            wf_files = self.args.get('wdl_child_filenames', [])
-            localdir = self.args['wdl_directory_local']
-        elif language == 'snakemake':
-            main_wf = self.args['snakemake_main_filename']
-            wf_files = self.args.get('snakemake_child_filenames', [])
-            localdir = self.args['snakemake_directory_local']
-        else:
-            main_wf = self.args['cwl_main_filename']
-            wf_files = self.args.get('cwl_child_filenames', [])
-            localdir = self.args['cwl_directory_local']
-        wf_files.append(main_wf)
-        localdir = localdir.rstrip('/')
-        for wf_file in wf_files:
-            source = localdir + '/' + wf_file
-            target = key_prefix + wf_file
-            boto3.client('s3').upload_file(source, bucket, target)
-        return "s3://%s/%s" % (bucket, key_prefix)
+
+def upload_workflow_to_s3(unicorn_input):
+    """input is a UnicornInput object"""
+    args = unicorn_input.args
+    cfg = unicorn_input.cfg
+    jobid = unicorn_input.jobid
+    bucket = cfg.log_bucket
+    key_prefix = jobid + '.workflow/'
+    if args.language == 'wdl':
+        main_wf = args.wdl_main_filename
+        wf_files = args.wdl_child_filenames
+        localdir = args.wdl_directory_local
+    elif args.language == 'snakemake':
+        main_wf = args.snakemake_main_filename
+        wf_files = args.snakemake_child_filenames
+        localdir = args.snakemake_directory_local
+    elif args.language == 'shell':
+        pass
+    else:
+        main_wf = args.cwl_main_filename
+        wf_files = args.cwl_child_filenames
+        localdir = args.cwl_directory_local
+    wf_files.append(main_wf)
+    localdir = localdir.rstrip('/')
+    for wf_file in wf_files:
+        source = localdir + '/' + wf_file
+        target = key_prefix + wf_file
+        boto3.client('s3').upload_file(source, bucket, target)
+    url = "s3://%s/%s" % (bucket, key_prefix)
+    if args.language == 'wdl':
+        args.wdl_directory_url = url
+    elif args.language == 'snakemake':
+        args.snakemake_directory_url = url
+    elif args.language == 'shell':
+        pass
+    else:
+        args.cwl_directory_url = url
 
 
 def get_file_size(key, bucket, size_in_gb=False):

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -787,17 +787,17 @@ def upload_workflow_to_s3(unicorn_input):
     key_prefix = jobid + '.workflow/'
     if args.language == 'wdl':
         main_wf = args.wdl_main_filename
-        wf_files = args.wdl_child_filenames
+        wf_files = args.wdl_child_filenames.copy()
         localdir = args.wdl_directory_local
     elif args.language == 'snakemake':
         main_wf = args.snakemake_main_filename
-        wf_files = args.snakemake_child_filenames
+        wf_files = args.snakemake_child_filenames.copy()
         localdir = args.snakemake_directory_local
     elif args.language == 'shell':
         pass
     else:
         main_wf = args.cwl_main_filename
-        wf_files = args.cwl_child_filenames
+        wf_files = args.cwl_child_filenames.copy()
         localdir = args.cwl_directory_local
     wf_files.append(main_wf)
     localdir = localdir.rstrip('/')
@@ -829,4 +829,3 @@ def get_file_size(key, bucket, size_in_gb=False):
     if size_in_gb:
         size = size / one_gb
     return size
-

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -434,9 +434,6 @@ class Execution(object):
     def run_instances(self, ec2):
         return ec2.run_instances(**self.launch_args)
 
-    def donothing(self):
-        return ''
-
     def create_run_json_dict(self):
         args = self.args
         cfg = self.cfg

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -55,6 +55,7 @@ class UnicornInput(object):
 
     def as_dict(self):
         d = copy.deepcopy(self.__dict__)
+        del(d['cfg'])
         d['args'] = self.args.as_dict()
         d['config'] = self.cfg.as_dict()
         return d
@@ -97,7 +98,7 @@ class UnicornInput(object):
             dependency = args.dependency
         elif hasattr(cfg, 'dependency') and cfg.dependency:
             dependency = cfg.dependency
-        self.dependency = args.dependency = cfg.dependency = copy.deepcopy(dependency)
+        args.dependency = copy.deepcopy(dependency)
 
 
 class Args(object):

--- a/tibanna/exceptions.py
+++ b/tibanna/exceptions.py
@@ -40,3 +40,7 @@ class EC2InstanceLimitException(Exception):
 
 class EC2InstanceLimitWaitException(Exception):
     pass
+
+
+class MissingFieldInInputJsonException(Exception):
+    pass

--- a/tibanna/lambdas/requirements.txt
+++ b/tibanna/lambdas/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.7.42
 botocore==1.10.42
 urllib3==1.23
-Benchmark-4dn==0.5.2
+Benchmark-4dn==0.5.3

--- a/tibanna/run_task.py
+++ b/tibanna/run_task.py
@@ -59,8 +59,8 @@ def run_task(input_json):
     else:
         profile = None
 
-    exec = Execution(input_json)
-    exec.prelaunch(profile=profile)
-    exec.launch()
-    exec.postlaunch()
-    return(exec.input_dict)
+    execution = Execution(input_json)
+    execution.prelaunch(profile=profile)
+    execution.launch()
+    execution.postlaunch()
+    return(execution.input_dict)

--- a/tibanna/run_task.py
+++ b/tibanna/run_task.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
-import os
-import copy
-import boto3
 from .ec2_utils import Execution
 from .vars import (
     TIBANNA_PROFILE_ACCESS_KEY,
     TIBANNA_PROFILE_SECRET_KEY
 )
+
 
 def run_task(input_json):
     '''

--- a/tibanna/run_task.py
+++ b/tibanna/run_task.py
@@ -80,6 +80,9 @@ def run_task(input_json):
     for k in CONFIG_KEYS:
         assert k in cfg, "%s not in config_field" % k
 
+    if 'instance_type' in cfg and ('mem' in cfg and 'cpu' in cfg):
+        raise Exception("Use either instance_type or mem & cpu but not both")
+
     args = input_json_copy.get(ARGS_FIELD)
     for k in ARGS_KEYS:
         assert k in args, "%s not in args field" % k

--- a/tibanna/vars.py
+++ b/tibanna/vars.py
@@ -17,7 +17,7 @@ TIBANNA_REPO_NAME = os.environ.get('TIBANNA_REPO_NAME', '4dn-dcic/tibanna')
 TIBANNA_REPO_BRANCH = os.environ.get('TIBANNA_REPO_BRANCH', 'master')
 
 # Tibanna roles
-AWS_S3_ROLE_NAME = os.environ.get('AWS_S3_ROLE_NAME', '')
+AWS_S3_ROLE_NAME = os.environ.get('AWS_S3_ROLE_NAME', 'S3_access')
 S3_ACCESS_ARN = 'arn:aws:iam::' + AWS_ACCOUNT_NUMBER + ':instance-profile/' + AWS_S3_ROLE_NAME
 
 # Profile keys (optional) to use on AWSEM EC2

--- a/tibanna_4dn/lambdas/requirements.txt
+++ b/tibanna_4dn/lambdas/requirements.txt
@@ -1,5 +1,5 @@
 dcicutils==0.6.0
-Benchmark-4dn==0.5.2
+Benchmark-4dn==0.5.3
 boto3==1.7.42
 botocore==1.10.42
 urllib3==1.23

--- a/tibanna_4dn/lambdas/start_run_awsem.py
+++ b/tibanna_4dn/lambdas/start_run_awsem.py
@@ -13,7 +13,7 @@ config = {
     'region': AWS_REGION,
     'runtime': 'python3.6',
     'role': 'lambda_full_s3',
-    'description': 'Tibanna pony update_ffmeta_awsem',
+    'description': 'Tibanna pony start_run_awsem',
     'timeout': 300,
     'memory_size': 256
 }


### PR DESCRIPTION
### deploy
@carlvitzthum 
Fixed a new issue of `deploy_unicorn` or `deploy_core` `--usergroup` option not working.
These functions also now delete existing lambdas to avoid a weird AWS Lambda KMS error after updating an existing function.

### run
`run_task.py` and `ec2_utils.py` are refactored. Now we have classes `UnicornInput` (input json for unicorn), `Args` and `Config` (args and config fields of the input json), `Execution` (that includes `UnicornInput` as a member and has all the functions related to preparing and launching awsem).

Now `mem` and `cpu` can be specified instead of or with `instance_type` in the input json. The top 10 instances (in terms of cost) will be chosen that satisfies the `mem` and `cpu`. If `instance_type` is also specified, that instance will be the first choice. `behavior_on_capacity_limit` now can have a value `other_instance_types` along with `fail`, `wait_and_retry` (in which case Tibanna will use only the first instance in the list) and `try_without_spot` (switch to non-spot, in case of spot instance).

`ebs_size` can be set in the format of `3x`, `5.5x` etc. (3 or 5.5 times total input size).