### PR TITLE
Benchmark

### DIFF
--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -119,7 +119,8 @@ class Args(SerializableObject):
     def fill_default(self):
         for field in ['input_files', 'input_parameters', 'input_env',
                       'secondary_files', 'output_target',
-                      'secondary_output_target', 'alt_cond_output_argnames']:
+                      'secondary_output_target', 'alt_cond_output_argnames',
+                      'additional_benchmarking_parameters']:
             if not hasattr(self, field):
                 setattr(self, field, {})
         for field in ['app_version']:
@@ -438,9 +439,11 @@ class Execution(object):
         return input_size_in_bytes
 
     def get_benchmarking(self, input_size_in_bytes):
+        benchmark_parameters = copy.deepcopy(self.args.input_parameters)
+        benchmark_parameters.update(self.args.additional_benchmarking_parameters)
         try:
             res = B.benchmark(self.args.app_name, {'input_size_in_bytes': input_size_in_bytes,
-                                                   'parameters': self.args.input_parameters})
+                                                   'parameters': benchmark_parameters})
         except:
             try:
                 res

--- a/tibanna_4dn/start_run.py
+++ b/tibanna_4dn/start_run.py
@@ -134,8 +134,9 @@ def start_run(input_json):
     ff_meta.post(key=tbn.ff_keys)
 
     # parameters
-    args['input_parameters'] = input_json_copy.get('parameters')
-
+    args['input_parameters'] = input_json_copy.get('parameters', {})
+    args['additional_benchmarking_parameters'] = input_json_copy.get('additional_benchmarking_parameters', {})
+    
     # output target
     args['output_target'] = dict()
     args['secondary_output_target'] = dict()


### PR DESCRIPTION
New field `additional_benchmarking_parameters` (either at the first level of pony input json or inside `args` of unicorn input json) that gets passed on only to the benchmarking function as part of `parameters`. (Could be useful to pass parameters that are not needed for workflow run but are needed for benchmarking e.g. read count of a fastq file)
