### PR TITLE
Error message fixes for terminate_idle_instance function

### DIFF
--- a/tibanna/check_task.py
+++ b/tibanna/check_task.py
@@ -112,7 +112,7 @@ class CheckTask(object):
             end = datetime.now(tzutc())
             start = end - timedelta(hours=1)
             jobstart_time = boto3.client('s3').get_object(Bucket=bucket_name, Key=job_started).get('LastModified')
-            if jobstart_time + timedelta(hours=1) < end:
+            if False and jobstart_time + timedelta(hours=1) < end:
                 try:
                     cw_res = self.TibannaResource(instance_id, filesystem, start, end).as_dict()
                 except Exception as e:
@@ -137,9 +137,10 @@ class CheckTask(object):
                              (jobid, str(cpu), str(ebs_read))
                     raise EC2IdleException(errmsg)
                 except Exception as e:
-                    errmsg = "Nothing has been running for the past hour for job %s," + \
-                             "but cannot terminate the instance (cpu utilization (%s) : %s" % \
-                             jobid, str(cpu), str(e)
+                    errmsg = (
+                        "Nothing has been running for the past hour for job %s,"
+                        "but cannot terminate the instance - cpu utilization (%s) : %s"
+                    ) %  (jobid, str(cpu), str(e))
                     printlog(errmsg)
                     raise EC2IdleException(errmsg)
 

--- a/tibanna/check_task.py
+++ b/tibanna/check_task.py
@@ -112,7 +112,7 @@ class CheckTask(object):
             end = datetime.now(tzutc())
             start = end - timedelta(hours=1)
             jobstart_time = boto3.client('s3').get_object(Bucket=bucket_name, Key=job_started).get('LastModified')
-            if False and jobstart_time + timedelta(hours=1) < end:
+            if jobstart_time + timedelta(hours=1) < end:
                 try:
                     cw_res = self.TibannaResource(instance_id, filesystem, start, end).as_dict()
                 except Exception as e:
@@ -132,9 +132,10 @@ class CheckTask(object):
                 # in case the instance is copying files using <1% cpu for more than 1hr, do not terminate it.
                 try:
                     boto3.client('ec2').terminate_instances(InstanceIds=[instance_id])
-                    errmsg = "Nothing has been running for the past hour for job %s " + \
-                             "(CPU utilization %s and EBS read %s bytes)." % \
-                             (jobid, str(cpu), str(ebs_read))
+                    errmsg = (
+                        "Nothing has been running for the past hour for job %s,"
+                        "(CPU utilization %s and EBS read %s bytes)."
+                    ) %  (jobid, str(cpu), str(ebs_read))
                     raise EC2IdleException(errmsg)
                 except Exception as e:
                     errmsg = (


### PR DESCRIPTION
This function includes the creation of two different format strings that were bugged. The second message doesn't have the format arguments grouped correctly (needed to add parenthesis).

Both error messages include the same bug related to precedence in python. Specifcally, "%" has a higher precedence than "+" regardless of what types are interacting with the operator. As a result, python was trying to evaluate the format string before concattenating the format strings which raises an error due to having non matching numbers of "%s" and arguments. I've fixed this bug by switching the string concatenation to an alternative style. Specifcally, strings inside parenthesis that aren't separated by commas are automatically concatenated by python.