### PR TITLE
1.0.1

### DIFF
--- a/awsf3-docker/Dockerfile
+++ b/awsf3-docker/Dockerfile
@@ -82,7 +82,7 @@ RUN pip install ec2metadata==2.0.1
 RUN wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar && \
     ln -s cromwell-53.1.jar cromwell.jar
 # Old cromwell for WDL draft-2
-RUN wget https://github.com/broadinstitute/cromwell/releases/download/31/cromwell-31.jar
+RUN wget https://github.com/broadinstitute/cromwell/releases/download/35/cromwell-35.jar
 RUN wget https://github.com/broadinstitute/cromwell/blob/develop/LICENSE.txt  # cromwell license
 
 # awsf scripts

--- a/awsf3-docker/run.sh
+++ b/awsf3-docker/run.sh
@@ -95,7 +95,7 @@ exl echo "## $(python --version)"
 exl echo "## $(pip --version | cut -f1,2 -d' ')"
 exl echo "## tibanna awsf3 version $(tibanna --version | cut -f2 -d' ')"
 exl echo "## cwltool version $(cwltool --version | cut -f2 -d' ')"
-exl echo "## cromwell version $(java -jar /usr/local/bin/cromwell-31.jar --version | cut -f2 -d ' ') for WDL draft2"
+exl echo "## cromwell version $(java -jar /usr/local/bin/cromwell-35.jar --version | cut -f2 -d ' ') for WDL draft2"
 exl echo "## cromwell version $(java -jar /usr/local/bin/cromwell.jar --version | cut -f2 -d ' ') for WDL v1.0"
 exl echo "## $(singularity --version)"
 
@@ -189,12 +189,7 @@ echo "*/1 * * * * /usr/local/bin/cron.sh -l $LOGBUCKET -L $LOGFILE -t $TOPFILE -
 exl echo
 exl echo "## Running CWL/WDL/Snakemake/Shell commands"
 exl echo
-if [[ $LANGUAGE == 'wdl' ]]
-then
-  exl echo "## workflow language: $LANGUAGE (wdl_draft2)"
-else
-  exl echo "## workflow language: $LANGUAGE"
-fi
+exl echo "## workflow language: $LANGUAGE"
 exl echo "## $(docker info | grep 'Operating System')"
 exl echo "## $(docker info | grep 'Docker Root Dir')"
 exl echo "## $(docker info | grep 'CPUs')"
@@ -204,13 +199,14 @@ send_log
 cwd0=$(pwd)
 cd $LOCAL_WFDIR  
 mkdir -p $LOCAL_WF_TMPDIR
-if [[ $LANGUAGE == 'wdl_v1' ]]
+if [[ $LANGUAGE == 'wdl_v1' || $LANGUAGE == 'wdl' ]]
 then
   exl java -jar /usr/local/bin/cromwell.jar run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE
   handle_error $?
-elif [[ $LANGUAGE == 'wdl_draft2' || $LANGUAGE == 'wdl' ]]  # 'wdl' defaults to 'wdl_draft2' for backward compatibility
+elif [[ $LANGUAGE == 'wdl_draft2' ]]  # 'wdl' defaults to 'wdl_v1'
 then
-  exl java -jar /usr/local/bin/cromwell-31.jar run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE
+  exl echo "## using cromwell-35 for WDL draft2"
+  exl java -jar /usr/local/bin/cromwell-35.jar run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE
   handle_error $?
 elif [[ $LANGUAGE == 'snakemake' ]]
 then

--- a/docs/wdl.rst
+++ b/docs/wdl.rst
@@ -2,5 +2,5 @@
 Workflow Description Language (WDL)
 ===================================
 
-Tibanna version < ``1.0.0`` supports WDL draft-2, through Cromwell binary version 31. Tibanna version >= ``1.0.0`` supports both WDL draft-2 and v1.0, through Cromwell binary version 31 and 53, respectively. This is because some of our old WDL pipelines written in draft-2 version no longer works with the new Cromwell version and we wanted to ensure the backward compatibility. But if you want to use WDL draft-2, specify ``"language": "wdl_draft2"`` instead of ``"language": "wdl"`` which defaults to WDL v1.0.
+Tibanna version < ``1.0.0`` supports WDL draft-2, through Cromwell binary version 35. Tibanna version >= ``1.0.0`` supports both WDL draft-2 and v1.0, through Cromwell binary version 35 and 53, respectively. This is because some of our old WDL pipelines written in draft-2 version no longer works with the new Cromwell version and we wanted to ensure the backward compatibility. But if you want to use WDL draft-2, specify ``"language": "wdl_draft2"`` instead of ``"language": "wdl"`` which defaults to WDL v1.0.
 

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.0.1b2"
+__version__ = "1.0.1"

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.0.0"
+__version__ = "1.0.1b2"

--- a/tibanna/top.py
+++ b/tibanna/top.py
@@ -69,7 +69,7 @@ class Top(object):
                     '/usr/bin/python3 /usr/local/bin/awsf3',
                     '/usr/bin/python3 /usr/local/bin/aws s3',
                     'java -jar /usr/local/bin/cromwell.jar',
-                    'java -jar /usr/local/bin/cromwell-31.jar']
+                    'java -jar /usr/local/bin/cromwell-35.jar']
 
     def __init__(self, contents):
         """initialization parsed top output content and


### PR DESCRIPTION
* `wdl` -> `wdl_v1` not `wdl_draft2` (to be consistent with the documentation)
* cromwell 35 is used for `wdl_draft2` instead of cromwell 31.