### PR TITLE
Add cost estimate type

### DIFF
--- a/tests/tibanna/unicorn/test_ec2_utils.py
+++ b/tests/tibanna/unicorn/test_ec2_utils.py
@@ -780,7 +780,8 @@ def test_ec2_cost_estimate_missing_availablity_zone():
 
     postrunjsonobj = json.loads(postrunjsonstr)
     postrunjson = AwsemPostRunJson(**postrunjsonobj)
-    assert get_cost_estimate(postrunjson) == 0.0
+    estimate, cost_estimate_type = get_cost_estimate(postrunjson)
+    assert estimate == 0.0
 
 
 def test_ec2_cost_estimate_medium_nonspot():
@@ -795,7 +796,7 @@ def test_ec2_cost_estimate_medium_nonspot():
     aws_price_overwrite = {
         'ec2_ondemand_price': 0.0416, 'ebs_root_storage_price': 0.08
         } 
-    estimate = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
+    estimate, cost_estimate_type = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
     assert estimate == 0.004384172839506173
 
 
@@ -811,7 +812,7 @@ def test_ec2_cost_estimate_small_spot():
     aws_price_overwrite = {
         'ec2_spot_price': 0.0064, 'ebs_root_storage_price': 0.08
         } 
-    estimate = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
+    estimate, cost_estimate_type = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
     assert estimate == 0.0009326172839506175
 
 
@@ -827,7 +828,7 @@ def test_ec2_cost_estimate_small_spot_gp3_iops():
     aws_price_overwrite = {
         'ec2_spot_price': 0.0064, 'ebs_root_storage_price': 0.08, 'ebs_gp3_iops_price': 0.005
         } 
-    estimate = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
+    estimate, cost_estimate_type = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
     assert estimate == 0.0012730879629629633
 
 
@@ -843,6 +844,6 @@ def test_ec2_cost_estimate_small_spot_io2_iops():
     aws_price_overwrite = {
         'ec2_spot_price': 0.0064, 'ebs_root_storage_price': 0.08, 'ebs_storage_price': 0.125, 'ebs_io2_iops_prices': [0.065, 0.0455, 0.03185]
         } 
-    estimate = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
+    estimate, cost_estimate_type = get_cost_estimate(postrunjson, aws_price_overwrite=aws_price_overwrite)
     assert estimate == 0.029224481481481476
     

--- a/tibanna/__main__.py
+++ b/tibanna/__main__.py
@@ -458,7 +458,8 @@ def cost(job_id, sfn=TIBANNA_DEFAULT_STEP_FUNCTION_NAME, update_tsv=False):
 
 def cost_estimate(job_id, update_tsv=False):
     """print out estimated cost of a specific job"""
-    print(API().cost_estimate(job_id=job_id, update_tsv=update_tsv))
+    cost_estimate, cost_estimate_type = API().cost_estimate(job_id=job_id, update_tsv=update_tsv)
+    print(f'{cost_estimate} ({cost_estimate_type})')
 
 
 def cleanup(usergroup, suffix='', purge_history=False, do_not_remove_iam_group=False, do_not_ignore_errors=False, quiet=False):

--- a/tibanna/check_task.py
+++ b/tibanna/check_task.py
@@ -10,9 +10,6 @@ from .utils import (
     does_key_exist,
     read_s3
 )
-from .pricing_utils import (
-    get_cost_estimate
-)
 from .awsem import (
     AwsemPostRunJson
 )
@@ -190,13 +187,11 @@ class CheckTask(object):
 
     def handle_metrics(self, prj):
         try:
-            estimate, cost_estimate_type = get_cost_estimate(prj)
             resources = self.TibannaResource(prj.Job.instance_id,
                                              prj.Job.filesystem,
                                              prj.Job.start_time_as_str,
-                                             prj.Job.end_time_as_str or datetime.now(),
-                                             cost_estimate = estimate,
-                                             cost_estimate_type=cost_estimate_type)
+                                             prj.Job.end_time_as_str or datetime.now())
+
         except Exception as e:
             raise MetricRetrievalException("error getting metrics: %s" % str(e))
         prj.Job.update(Metrics=resources.as_dict())

--- a/tibanna/check_task.py
+++ b/tibanna/check_task.py
@@ -190,12 +190,13 @@ class CheckTask(object):
 
     def handle_metrics(self, prj):
         try:
-            estimate = get_cost_estimate(prj)
+            estimate, cost_estimate_type = get_cost_estimate(prj)
             resources = self.TibannaResource(prj.Job.instance_id,
                                              prj.Job.filesystem,
                                              prj.Job.start_time_as_str,
                                              prj.Job.end_time_as_str or datetime.now(),
-                                             cost_estimate = estimate)
+                                             cost_estimate = estimate,
+                                             cost_estimate_type=cost_estimate_type)
         except Exception as e:
             raise MetricRetrievalException("error getting metrics: %s" % str(e))
         prj.Job.update(Metrics=resources.as_dict())

--- a/tibanna/core.py
+++ b/tibanna/core.py
@@ -53,7 +53,8 @@ from .pricing_utils import (
     get_cost,
     get_cost_estimate,
     update_cost_estimate_in_tsv,
-    update_cost_in_tsv
+    update_cost_in_tsv,
+    get_cost_estimate_from_tsv
 )
 from .ami import AMI
 # from botocore.errorfactory import ExecutionAlreadyExists
@@ -1095,8 +1096,9 @@ class API(object):
             self.TibannaResource.update_html(log_bucket, job_id + '.metrics/')
         else:
             try:
-                cost_estimate = self.cost_estimate(job_id=job_id)
-                M = self.TibannaResource(instance_id, filesystem, starttime, endtime, cost_estimate = cost_estimate)
+                # We don't want to recompute the cost estimate - we take it from the tsv
+                cost_estimate, cost_estimate_type = get_cost_estimate_from_tsv(log_bucket, job_id)
+                M = self.TibannaResource(instance_id, filesystem, starttime, endtime, cost_estimate = cost_estimate, cost_estimate_type=cost_estimate_type)
                 top_content = self.log(job_id=job_id, top=True)
                 M.plot_metrics(instance_type, directory, top_content=top_content)
             except Exception as e:
@@ -1124,17 +1126,17 @@ class API(object):
         precise_cost = self.cost(job_id, update_tsv=False)
         if(precise_cost and precise_cost > 0.0):
             if update_tsv:
-                update_cost_estimate_in_tsv(log_bucket, job_id, precise_cost)
+                update_cost_estimate_in_tsv(log_bucket, job_id, precise_cost, cost_estimate_type="actual cost")
             return precise_cost
 
         # awsf_image was added in 1.0.0. We use that to get the correct ebs root type
         ebs_root_type = 'gp3' if 'awsf_image' in postrunjsonobj['config'] else 'gp2'
 
-        cost = get_cost_estimate(postrunjson, ebs_root_type)
+        cost_estimate, cost_estimate_type = get_cost_estimate(postrunjson, ebs_root_type)
 
         if update_tsv:
-            update_cost_estimate_in_tsv(log_bucket, job_id, cost)
-        return cost
+            update_cost_estimate_in_tsv(log_bucket, job_id, cost_estimate, cost_estimate_type)
+        return cost_estimate
 
     def cost(self, job_id, sfn=None, update_tsv=False):
         if not sfn:

--- a/tibanna/cw_utils.py
+++ b/tibanna/cw_utils.py
@@ -359,13 +359,14 @@ class TibannaResource(object):
         cost = d['Cost'] if 'Cost' in d else '---'
         estimated_cost = (float)(d['Estimated_Cost']) if 'Estimated_Cost' in d else 0.0
         estimated_cost = str(estimated_cost) if estimated_cost > 0.0 else '---'
+        cost_estimate_type = d['Estimated_Cost_Type'] if 'Estimated_Cost_Type' in d else "NA"
         instance = d['Instance_Type'] if 'Instance_Type' in d else '---'
         # writing
         html_content = cls.create_html() % (cls.report_title, instance,
                              d['Maximum_Memory_Used_Mb'], d['Minimum_Memory_Available_Mb'], d['Maximum_Disk_Used_Gb'],
                              d['Maximum_Memory_Utilization'], d['Maximum_CPU_Utilization'], d['Maximum_Disk_Utilization'],
                              cost,
-                             estimated_cost,
+                             estimated_cost, cost_estimate_type,
                              str(starttime), str(endtime), str(endtime-starttime)
                             )
         s3_key = os.path.join(prefix, 'metrics.html')
@@ -429,6 +430,7 @@ class TibannaResource(object):
             fo.write('End_Time' + '\t' + str(self.end) + '\n')
             fo.write('Instance_Type' + '\t' + instance_type + '\n')
             fo.write('Estimated_Cost' + '\t' + str(self.cost_estimate) + '\n')
+            fo.write('Estimated_Cost_Type' + '\t' + str(self.cost_estimate_type) + '\n')
         return(filename)
 
     @staticmethod

--- a/tibanna/cw_utils.py
+++ b/tibanna/cw_utils.py
@@ -29,7 +29,7 @@ class TibannaResource(object):
     def convert_timestamp_to_datetime(cls, timestamp):
         return datetime.strptime(timestamp, cls.timestamp_format)
 
-    def __init__(self, instance_id, filesystem, starttime, endtime=datetime.utcnow(), cost_estimate = 0.0):
+    def __init__(self, instance_id, filesystem, starttime, endtime=datetime.utcnow(), cost_estimate = 0.0, cost_estimate_type = "NA"):
         """All the Cloudwatch metrics are retrieved and stored at the initialization.
         :param instance_id: e.g. 'i-0167a6c2d25ce5822'
         :param filesystem: e.g. "/dev/xvdb", "/dev/nvme1n1"
@@ -52,6 +52,7 @@ class TibannaResource(object):
         self.nTimeChunks = nTimeChunks
         self.list_files = []
         self.cost_estimate = cost_estimate
+        self.cost_estimate_type = cost_estimate_type
         self.get_metrics(nTimeChunks)
 
     def get_metrics(self, nTimeChunks=1):
@@ -332,7 +333,7 @@ class TibannaResource(object):
                              str(self.max_mem_utilization_percent), str(self.max_cpu_utilization_percent),
                              str(self.max_disk_space_utilization_percent),
                              '---', # cost placeholder for now
-                             cost_estimate, 
+                             cost_estimate, self.cost_estimate_type,
                              str(self.start), str(self.end), str(self.end - self.start)
                             )
                     )
@@ -620,7 +621,7 @@ class TibannaResource(object):
                       </tr>
                       <tr>
                         <td class="left">Cost (estimated) (USD)</td>
-                        <td class="center">%s</td>
+                        <td class="center">%s (%s)</td>
                       </tr>
                     </table>
                     </br></br>

--- a/tibanna/pricing_utils.py
+++ b/tibanna/pricing_utils.py
@@ -431,8 +431,12 @@ def update_cost_estimate_in_tsv(log_bucket, job_id, cost_estimate, cost_estimate
         # Remove Estimated_Cost and Estimated_Cost_Type from file, since we want to update it
         if("Estimated_Cost" in row.split("\t") or "Estimated_Cost_Type" in row.split("\t")):
             continue
+        if("Cost" in row.split("\t") and cost_estimate_type=="actual cost"):
+            continue
         write_file = write_file + row + '\n'
 
+    if(cost_estimate_type=="actual cost"):
+        write_file = write_file + 'Cost\t' + str(cost_estimate) + '\n'
     write_file = write_file + 'Estimated_Cost\t' + str(cost_estimate) + '\n'
     write_file = write_file + 'Estimated_Cost_Type\t' + cost_estimate_type + '\n'
     put_object_s3(content=write_file, key=s3_key, bucket=log_bucket)


### PR DESCRIPTION
- Added `Estimated_Cost_Type` to the `metrics_report.tsv`. It can be "immediate estimate", "actual cost" or "retrospective estimate". The plot metrics html has been modified accordingly. `cost_estimate` will also return this together with the estimate
- `plot_metrics` now tries to retrieve the cost estimate from the tsv instead of calculating it every time the command is run (more accurate since AWS prices change over time).
- `cost_estimate -j ... -u` now does not update the tsv, if the estimate is retrospective and an immediate estimate (or actual cost) is already in the tsv.