### PR TITLE
Allow tagging of output files

### DIFF
--- a/awsf3/target.py
+++ b/awsf3/target.py
@@ -70,8 +70,6 @@ class Target(object):
             if 'bucket_name' in target_value:  # this allows using different output buckets
                 self.bucket = target_value['bucket_name']
             if 'tag' in target_value:  # adds object-level tags to the output files
-                if ':' not in target_value['tag']:
-                    raise Exception("The tag must be of the form Key:Value")
                 self.tag = target_value['tag']
             if 'object_prefix' in target_value:
                 if 'object_key' in target_value:
@@ -124,8 +122,8 @@ class Target(object):
         if encrypt_s3_upload:
             upload_extra_args = {'ServerSideEncryption': 'aws:kms'}
         if self.tag is not None:
-            tag_dict = self.tag.split(':')
-            upload_extra_args.update({'Metadata': {tag_dict[0]: tag_dict[1]}})
+            upload_extra_args.update({'Tagging': self.tag})
+            print("Tagging:", self.tag)
         if os.path.isdir(self.source):
             print("source " + self.source + " is a directory")
             print("uploading output directory %s to %s in bucket %s" % (self.source, self.dest, self.bucket))
@@ -164,7 +162,7 @@ class Target(object):
                                    'Key': self.dest + arcfile['name'],
                                    'Body': arcfile['content'],
                                    'ContentType': content_type}
-                if encrypt_s3_upload:
+                if encrypt_s3_upload or (self.tag is not None):
                     put_object_args.update(upload_extra_args)
                 try:
                     print("Putting object %s to %s in bucket %s" % (arcfile['name'], self.dest + arcfile['name'], self.bucket))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -569,7 +569,7 @@ To retrieve the cost and update the metrics report file created with plot_metric
 cost_estimate
 ----
 
-Retrieve a cost estimate for a specific job. This will be available as soon as the job finished. This function will return the exact cost, if it is available
+Retrieve a cost estimate for a specific job. This will be available as soon as the job finished. This function will return the exact cost, if it is available. The cost estimate will also indicate if it is an immediate estimate (i.e., the exact cost is not yet available), the actual cost or the retrospective estimate (i.e., the exact cost is not available anymore). In case the estimate returns the actual cost and the `-u` parameter is set, the cost row in the metrics file will be automatically updated.
 
 ::
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -577,6 +577,7 @@ cost_estimate
 ----
 
 To retrieve cost estimates and update the metrics report file created with plot_metrics. In contrast to the exact costs, the estimated costs are available immediately after the job has completed.
+The cost estimate will also indicate if it is an immediate estimate (i.e., the exact cost is not yet available), the actual cost or the retrospective estimate (i.e., the exact cost is not available anymore). In case the estimate returns the actual cost and the `-u` parameter is set, the cost row in the metrics file will be automatically updated.
 This function requires a (deployed) Tibanna version >=1.0.6.
 
 ::

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -373,6 +373,15 @@ Output target specification
               "unzip": true
         }
 
+    - One or multiple tags can be automatically added to each ouput file by specifying the ``tag`` key. In the following example, two (object-level) tags are added to the result file. Note that the tag-set must be encoded as URL Query parameters. In case the ``unzip`` key is specified in addition to the ``tag`` key, each file in the output directory will be tagged.
+
+    ::
+
+        {
+           "out_zip": {
+              "object_key": "result.txt",
+              "tag": "Key1=Value1&Key2=Value2"
+        }
 
 
 :secondary_output_target:

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -335,7 +335,7 @@ Output target specification
     - It is highly recommended to stick to using only argument names for CWL/WDL for pipeline
       reproducibility, since they are already clearly defined in CWL/WDL (especially for CWL).
 
-    - Starting with version ``1.0.0``, a dictionary format is also accepted for individual target, with keys ``object_key`` ``bucket_name``, ``object_prefix`` and/or  ``unzip``. For a regular file output, ``object_key`` and ``bucket_name`` can be used. The use of ``bucket_name`` here allows using a different output bucket for specific output files. For a directory, ``object_prefix`` can be used instead which will be used as if it is the directory name on S3. ``object_prefix`` may or may not have the trailing ``\``. ``unzip`` is boolean (either ``true`` or ``false``) and can be applied to a case when the output file is a ``zip`` file and you want the content to be extracted into a directory on an S3 bucket.
+    - Starting with version ``1.0.0``, a dictionary format is also accepted for individual target, with keys ``object_key`` ``bucket_name``, ``object_prefix`` and/or  ``unzip``. For a regular file output, ``object_key`` and ``bucket_name`` can be used. The use of ``bucket_name`` here allows using a different output bucket for specific output files. For a directory, ``object_prefix`` can be used instead which will be used as if it is the directory name on S3. ``object_prefix`` may or may not have the trailing ``/``. ``unzip`` is boolean (either ``true`` or ``false``) and can be applied to a case when the output file is a ``zip`` file and you want the content to be extracted into a directory on an S3 bucket.
 
     - (e.g.
 
@@ -352,7 +352,7 @@ Output target specification
         {
             "out_pairsam": { 
                "object_key": "output/renamed_pairsam_file",
-               "bucket" : "some_different_bucket"
+               "bucket_name" : "some_different_bucket"
             }
         }
 
@@ -361,7 +361,7 @@ Output target specification
         {
             "some_output_as_dir": {
                 "object_prefix": "some_dir_output/",
-                "bucket": "some_different_bucket"
+                "bucket_name": "some_different_bucket"
             }
         }
 

--- a/tests/awsf3/test_target.py
+++ b/tests/awsf3/test_target.py
@@ -228,7 +228,8 @@ def test_target_as_dict():
     assert target.as_dict() == {'source': 'some_source',
                                 'dest': 'some_dest',
                                 'bucket': 'some_bucket',
-                                'unzip': False}
+                                'unzip': False,
+                                'tag': None}
 
 
 def test_secondary_target_is_matched():

--- a/tests/awsf3/test_target.py
+++ b/tests/awsf3/test_target.py
@@ -81,6 +81,11 @@ def test_target_parse_target_value_unzip():
     assert target.bucket == 'some_bucket'
     assert target.unzip is True
 
+def test_target_parse_target_value_tag():
+    target = Target('some_bucket')
+    target.parse_target_value({'tag': 'Key1=Name1'})
+    assert target.tag == 'Key1=Name1'
+
 
 def test_target_parse_target_value_unzip_wo_prefix():
     target = Target('some_bucket')

--- a/tests/tibanna/unicorn/run_task_awsem/event_tagging.json
+++ b/tests/tibanna/unicorn/run_task_awsem/event_tagging.json
@@ -1,0 +1,34 @@
+{
+  "args": {
+    "app_name": "shell-test",
+    "input_parameters": {},
+    "language": "shell",
+    "command": "\\$ECHO_COMMAND \"haha\" > /data1/out/shell-test-output; ls -l somefile >> /data1/out/shell-test-output",
+    "container_image": "ubuntu:16.04",
+    "output_target": {
+      "file:///data1/out/shell-test-output": {
+            "object_key": "shell-test-output2",
+            "tag": "Name=shell-test-output&Type=processed_file"
+        }
+    },
+    "secondary_output_target": {},
+    "secondary_files": {},
+    "output_S3_bucket": "soos-4dn-bucket",
+    "app_version": "5",
+    "input_files": {
+        "file:///data1/shell/somefile": "s3://soos-4dn-bucket/hg38.blacklist.bed.gz"
+    },
+    "input_parameters": {
+    },
+    "input_env": {
+        "ECHO_COMMAND": "echo"
+    }
+  },
+  "config": {
+    "mem": 2,
+    "cpu": 1,
+    "ebs_size": 10,
+    "EBS_optimized": false,
+    "log_bucket": "tibanna-output"
+  }
+}

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/tibanna/iam_utils.py
+++ b/tibanna/iam_utils.py
@@ -183,7 +183,8 @@ class IAM(object):
                         "s3:PutObject",
                         "s3:GetObject",
                         "s3:DeleteObject",
-                        "s3:PutObjectAcl"
+                        "s3:PutObjectAcl",
+                        "s3:PutObjectTagging"
                     ],
                     "Resource": resource_list_objects
                 }


### PR DESCRIPTION
Allow tagging of output files by adding a tag key:
```
"output_target": {
      "report": {
        "object_key": "output/my_first_md5_report_tagged",
        "tag" : "Key1=Value1&Key2=Value2"
      }
    },
```
You can try it with `"awsf_image": "aveit/tibanna-awsf:1.1.2.dev5",`
