### PR TITLE
Fix metrics report, when top commands contain double quotes

### DIFF
--- a/tibanna/top.py
+++ b/tibanna/top.py
@@ -231,9 +231,9 @@ class Top(object):
             last_minute = 5
         with open(csv_file, 'w') as fo:
             # header
-            # we have to remove any double quotes that are present in the cmd, before wrapping it in double quotes. Otherwise we 
+            # we have to escape any double quotes that are present in the cmd, before wrapping it in double quotes. Otherwise we 
             # will get incorrect column counts when creating the metrics report.
-            fo.write(delimiter.join([colname_for_timestamps] + [Top.wrap_in_double_quotes(cmd.replace('"', "'")) for cmd in self.commands]))
+            fo.write(delimiter.join([colname_for_timestamps] + [Top.wrap_in_double_quotes(cmd.replace('"', '""')) for cmd in self.commands]))
             fo.write('\n')
             # contents
             # skip timepoints earlier than timestamp_start

--- a/tibanna/top.py
+++ b/tibanna/top.py
@@ -231,7 +231,9 @@ class Top(object):
             last_minute = 5
         with open(csv_file, 'w') as fo:
             # header
-            fo.write(delimiter.join([colname_for_timestamps] + [Top.wrap_in_double_quotes(cmd) for cmd in self.commands]))
+            # we have to remove any double quotes that are present in the cmd, before wrapping it in double quotes. Otherwise we 
+            # will get incorrect column counts when creating the metrics report.
+            fo.write(delimiter.join([colname_for_timestamps] + [Top.wrap_in_double_quotes(cmd.replace('"', "'")) for cmd in self.commands]))
             fo.write('\n')
             # contents
             # skip timepoints earlier than timestamp_start


### PR DESCRIPTION
If one of the top commands contain double quotes, the metrics report (CPU, memory usage) is currently broken.