### PR TITLE
return execArn for run_workflow

### DIFF
--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.2.6"
+__version__ = "1.2.7"


### PR DESCRIPTION
* jobid can be provided in input json (can be overwritten by run_workflow's jobid option)
* run_workflow response's response->executionArn points to the correct execution not the costupdater execution.