### PR TITLE
Updated link to public DOI instead of routing through a Harvard proxy.

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,7 +5,7 @@ News and updates
 Publication
 +++++++++++
 
-- **May 15, 2019**  Tibanna paper is out on Bioinformatics now! https://doi-org.ezp-prod1.hul.harvard.edu/10.1093/bioinformatics/btz379
+- **May 15, 2019**  Tibanna paper is out on Bioinformatics now! https://doi.org/10.1093/bioinformatics/btz379 
 - **Apr 18. 2019**  A newer version of the Tibanna paper is out on Biorxiv! https://www.biorxiv.org/content/10.1101/440974v3
 - **Oct 11. 2018**  Tibanna paper preprint is out on Biorxiv! https://www.biorxiv.org/content/early/2018/10/11/440974
 


### PR DESCRIPTION
Updated link to public DOI instead of routing through a Harvard proxy.