### PR TITLE
Spot failure detection

### DIFF
--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -200,9 +200,11 @@ send_log
 # run dockerized awsf scripts
 # wrap docker pull in some retry logic in case of
 # network failures (seen frequently) - Will Sept 22 2021
+exl echo "## Pulling Docker image"
 tries=0
 until [ "$tries" -ge 3 ] do
   if exl_no_error docker pull $AWSF_IMAGE; then 
+    exl echo "## Pull successfull on try $tries"
     break 
   else
     tries=$((tries+1))

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -158,8 +158,8 @@ exl echo
 exl echo "## Turning on Spot instance failure detection"
 curl https://raw.githubusercontent.com/4dn-dcic/tibanna/spot_failure_detection/awsf3/spot_failure_detection.sh -O
 chmod +x spot_failure_detection.sh
-echo "* * * * * ~/spot_failure_detection.sh -s 0 -l $LOGBUCKET -j $JOBID" >> ~/recurring.jobs
-echo "* * * * * ~/spot_failure_detection.sh -s 30 -l $LOGBUCKET -j $JOBID" >> ~/recurring.jobs
+echo "* * * * * ~/spot_failure_detection.sh -s 0 -l $LOGBUCKET -j $JOBID  >> /var/log/spot_failure_detection.log 2>&1" >> ~/recurring.jobs
+echo "* * * * * ~/spot_failure_detection.sh -s 30 -l $LOGBUCKET -j $JOBID  >> /var/log/spot_failure_detection.log 2>&1" >> ~/recurring.jobs
 
 # Send the collected jobs to cron
 cat recurring.jobs | crontab -

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,8 +153,9 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
-test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION"`
-"$test" > ~/test.log
+aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" > ~/test2.log 2>&1
+#test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION"`
+#"$test" > ~/test.log
 #test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"`
 
 cd ~

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,7 +153,8 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
-exl aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"
+test=aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"
+"$test" > ~/test.log
 cd ~
 exl echo
 exl echo "## Turning on Spot instance failure detection"

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,7 +153,7 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
-test=aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"
+test=aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"
 "$test" > ~/test.log
 cd ~
 exl echo

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -202,12 +202,12 @@ send_log
 # network failures (seen frequently) - Will Sept 22 2021
 exl echo "## Pulling Docker image"
 tries=0
-until [ "$tries" -ge 3 ] do
+until [ $tries -ge 3 ]; do
   if exl_no_error docker pull $AWSF_IMAGE; then 
     exl echo "## Pull successfull on try $tries"
     break 
   else
-    tries=$((tries+1))
+    ((tries++))
     sleep 1
   fi
 done

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -148,17 +148,21 @@ cd ~
 apt install -y unzip libwww-perl libdatetime-perl
 curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
 unzip CloudWatchMonitoringScripts-1.2.2.zip && rm CloudWatchMonitoringScripts-1.2.2.zip && cd aws-scripts-mon
-echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-path=/data1/ --from-cron" > cloudwatch.jobs
-echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util --disk-space-used --disk-path=/ --from-cron" >> cloudwatch.jobs
-cat cloudwatch.jobs | crontab -
+echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-path=/data1/ --from-cron" > ~/recurring.jobs
+echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util --disk-space-used --disk-path=/ --from-cron" >> ~/recurring.jobs
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
+cd ~
 exl echo
 exl echo "## Turning on Spot instance failure detection"
 curl https://github.com/4dn-dcic/tibanna/raw/spot_failure_detection/awsf3/spot_failure_detection.sh -O
-echo "* * * * * ~/spot_failure_detection.sh -s 0 -l $LOGBUCKET -j $JOBID" | crontab -
-echo "* * * * * ~/spot_failure_detection.sh -s 30 -l $LOGBUCKET -j $JOBID" | crontab -
+chmod +x spot_failure_detection.sh
+echo "* * * * * ~/spot_failure_detection.sh -s 0 -l $LOGBUCKET -j $JOBID" >> ~/recurring.jobs
+echo "* * * * * ~/spot_failure_detection.sh -s 30 -l $LOGBUCKET -j $JOBID" >> ~/recurring.jobs
+
+# Send the collected jobs to cron
+cat recurring.jobs | crontab -
 
 cd $cwd0
 

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -196,7 +196,14 @@ exl echo "## Running dockerized awsf scripts"
 send_log
 
 # run dockerized awsf scripts
-exl docker pull $AWSF_IMAGE
+# wrap docker pull in some retry logic in case of
+# network failures (seen frequently) - Will Sept 22 2021
+tries=0
+until [ "$tries" -ge 2 ] do
+  exl docker pull $AWSF_IMAGE && break
+  tries=$((tries+1))
+  sleep 1
+done
 send_log
 docker run --privileged --net host -v /home/ubuntu/:/home/ubuntu/:rw -v /mnt/:/mnt/:rw $AWSF_IMAGE run.sh -i $JOBID -l $LOGBUCKET -f $EBS_DEVICE -S $STATUS $SINGULARITY_OPTION_TO_PASS
 handle_error $?

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -156,7 +156,7 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 cd ~
 exl echo
 exl echo "## Turning on Spot instance failure detection"
-curl https://github.com/4dn-dcic/tibanna/raw/spot_failure_detection/awsf3/spot_failure_detection.sh -O
+curl https://raw.githubusercontent.com/4dn-dcic/tibanna/spot_failure_detection/awsf3/spot_failure_detection.sh -O
 chmod +x spot_failure_detection.sh
 echo "* * * * * ~/spot_failure_detection.sh -s 0 -l $LOGBUCKET -j $JOBID" >> ~/recurring.jobs
 echo "* * * * * ~/spot_failure_detection.sh -s 30 -l $LOGBUCKET -j $JOBID" >> ~/recurring.jobs

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,7 +153,7 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
-test=aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"
+test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"`
 "$test" > ~/test.log
 cd ~
 exl echo

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,6 +153,8 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
+aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" \ 
+ | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])" > ~/test.log
 cd ~
 exl echo
 exl echo "## Turning on Spot instance failure detection"

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -53,7 +53,7 @@ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity| grep Account | sed 's/[^0-9
 # function that executes a command and collecting log
 exl(){ $@ >> $LOGFILE 2>> $LOGFILE; handle_error $?; } ## usage: exl command  ## ERRCODE has the error code for the command. if something is wrong, send error to s3.
 exlo(){ $@ 2>> /dev/null >> $LOGFILE; handle_error $?; } ## usage: exlo command  ## ERRCODE has the error code for the command. if something is wrong, send error to s3. This one eats stderr. Useful for hiding long errors or credentials.
-exl_no_error(){ $@ >> $LOGFILE 2>> $LOGFILE; ] ## same as exl but will not exit on error
+exl_no_error(){ $@ >> $LOGFILE 2>> $LOGFILE; } ## same as exl but will not exit on error
 
 # function that sends log to s3 (it requires LOGBUCKET to be defined, which is done by sourcing $ENV_FILE.)
 send_log(){  aws s3 cp $LOGFILE s3://$LOGBUCKET &>/dev/null; }  ## usage: send_log (no argument)

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -140,7 +140,7 @@ mv $LOGFILE1 $LOGFILE2
 export LOGFILE=$LOGFILE2
 
 
-# set up cronjojb for cloudwatch metrics for memory, disk space and CPU utilization
+# set up cronjob for cloudwatch metrics for memory, disk space and CPU utilization
 exl echo
 exl echo "## Turning on cloudwatch metrics for memory and disk space"
 cwd0=$(pwd)
@@ -151,6 +151,15 @@ unzip CloudWatchMonitoringScripts-1.2.2.zip && rm CloudWatchMonitoringScripts-1.
 echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-path=/data1/ --from-cron" > cloudwatch.jobs
 echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util --disk-space-used --disk-path=/ --from-cron" >> cloudwatch.jobs
 cat cloudwatch.jobs | crontab -
+
+# set up cronjob to monitor AWS spot instance termination notice
+# Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
+exl echo
+exl echo "## Turning on Spot instance failure detection"
+curl https://github.com/4dn-dcic/tibanna/raw/spot_failure_detection/awsf3/spot_failure_detection.sh -O
+echo "* * * * * ~/spot_failure_detection.sh -s 0 -l $LOGBUCKET -j $JOBID" | crontab -
+echo "* * * * * ~/spot_failure_detection.sh -s 30 -l $LOGBUCKET -j $JOBID" | crontab -
+
 cd $cwd0
 
 # set additional profile

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,8 +153,10 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
-test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"`
+test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION"`
 "$test" > ~/test.log
+#test=`aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"`
+
 cd ~
 exl echo
 exl echo "## Turning on Spot instance failure detection"

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -153,8 +153,7 @@ echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util -
 
 # set up cronjob to monitor AWS spot instance termination notice
 # Since cron only has a resolution of 1 min, we set up 2 jobs and let one sleep for 30s, to get a resolution of 30s.
-aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" \ 
- | python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])" > ~/test.log
+exl aws ec2 describe-spot-instance-requests --filters Name=instance-id,Values="$(ec2metadata --instance-id)" --region "$INSTANCE_REGION" python3 -c "import sys, json; print(json.load(sys.stdin)['SpotInstanceRequests'])"
 cd ~
 exl echo
 exl echo "## Turning on Spot instance failure detection"

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -21,9 +21,13 @@ done
 sleep $SLEEP
 
 ### send spot_failure message to S3
-if [ ! -f $JOBID.$SLEEP.spot_failure ]; then
-    touch $JOBID.$SLEEP.spot_failure
-    aws s3 cp $JOBID.$SLEEP.spot_failure s3://$LOGBUCKET/$JOBID.$SLEEP.spot_failure
+if [ ! -f $JOBID.spot_failure ]; then
+    instance_action=$(ec2metadata --instance-action)
+    if [ "$instance_action" != "none" ]; 
+        touch $JOBID.spot_failure
+        echo "$instance_action" > $JOBID.spot_failure
+        aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure
+    fi    
 fi
 
 #echo "$LOGBUCKET / $JOBID"

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -31,6 +31,8 @@ if [ ! -f $JOBID.spot_failure ]; then
             echo "$instance_action" > $JOBID.spot_failure
             aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure
         fi    
+    else
+        echo "instance-action meta data could not be retrieved"
     fi 
     
 fi

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -26,7 +26,6 @@ if [ ! -f $JOBID.spot_failure ]; then
     # We are using IMDSv1 for performance reasons.
     status_code=`curl -s -o /dev/null -I -w "%{http_code}" http://169.254.169.254/latest/meta-data/instance-action`
     if [ "$status_code" = "200" ]; then
-        echo "Request successful"
         instance_action=`curl -s http://169.254.169.254/latest/meta-data/instance-action`
         if [ "$instance_action" != "none" ]; then
             echo "$instance_action" > $JOBID.spot_failure

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -24,11 +24,9 @@ sleep $SLEEP
 if [ ! -f $JOBID.spot_failure ]; then
     instance_action=$(ec2metadata --instance-action)
     if [ "$instance_action" != "none" ]; 
-        touch $JOBID.spot_failure
         echo "$instance_action" > $JOBID.spot_failure
         aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure
     fi    
 fi
 
-#echo "$LOGBUCKET / $JOBID"
 

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -19,12 +19,15 @@ while getopts "s:l:j:" opt; do
 done
 
 sleep $SLEEP
+echo "sleep $SLEEP"
 
 ### send spot_failure message to S3
 if [ ! -f $JOBID.spot_failure ]; then
+    echo "file not there"
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
     # We are using IMDSv1 for performance reasons.
     instance_action=`curl -s http://169.254.169.254/latest/meta-data/instance-action`
+    echo "instance action $instance_action"
     if [ "$instance_action" != "none" ]; 
         echo "$instance_action" > $JOBID.spot_failure
         aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -11,8 +11,8 @@ printHelpAndExit() {
 while getopts "s:l:j:" opt; do
     case $opt in
         s) SLEEP=$OPTARG;;  # execution delay in seconds
-        l) LOGBUCKET=$OPTARG;;  # bucket for sending log file
-        j) JOBID=$OPTARG;;  # job id
+        l) export LOGBUCKET=$OPTARG;;  # bucket for sending log file
+        j) export JOBID=$OPTARG;;  # job id
         h) printHelpAndExit 0;;
         [?]) printHelpAndExit 1;;
         esac

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -28,10 +28,9 @@ if [ ! -f $JOBID.spot_failure ]; then
     # This spot/instance-action is present only if the Spot Instance has been marked for hibernate, stop, or terminate.
     # Therefore it is sufficient to check if the request was successul.
     if [ "$status_code" = "200" ]; then
-        echo "$instance_action" > $JOBID.spot_failure
+        touch $JOBID.spot_failure
         aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure   
     fi 
-    
 fi
 
 

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -28,7 +28,7 @@ if [ ! -f $JOBID.spot_failure ]; then
     # We are using IMDSv1 for performance reasons.
     instance_action=`curl -s http://169.254.169.254/latest/meta-data/instance-action`
     echo "instance action $instance_action"
-    if [ "$instance_action" != "none" ]; 
+    if [ "$instance_action" != "none" ]; then
         echo "$instance_action" > $JOBID.spot_failure
         aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure
     fi    

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -20,13 +20,13 @@ done
 
 sleep $SLEEP
 
-### send spot_failure message to S3
+### Send spot_failure message to S3
 if [ ! -f $JOBID.spot_failure ]; then
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
     # We are using IMDSv1 for performance reasons and simplicity.
     status_code=`curl -s -o /dev/null -I -w "%{http_code}" http://169.254.169.254/latest/meta-data/spot/instance-action`
     # This spot/instance-action is present only if the Spot Instance has been marked for hibernate, stop, or terminate.
-    # Therefore it is sufficient to check if the request was successul.
+    # Therefore, it is sufficient to check if the request was successful.
     if [ "$status_code" = "200" ]; then
         touch $JOBID.spot_failure
         aws s3 cp $JOBID.spot_failure s3://$LOGBUCKET/$JOBID.spot_failure   

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -25,7 +25,7 @@ if [ ! -f $JOBID.spot_failure ]; then
     # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
     # We are using IMDSv1 for performance reasons.
     status_code=`curl -s -o /dev/null -I -w "%{http_code}" http://169.254.169.254/latest/meta-data/instance-action`
-    if [ "$status_code" != "200" ]; then
+    if [ "$status_code" = "200" ]; then
         echo "Request successful"
         instance_action=`curl -s http://169.254.169.254/latest/meta-data/instance-action`
         if [ "$instance_action" != "none" ]; then

--- a/awsf3/spot_failure_detection.sh
+++ b/awsf3/spot_failure_detection.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+shopt -s extglob
+
+printHelpAndExit() {
+    echo "Usage: ${0##*/} -s SLEEP -l LOGBUCKET -j JOBID"
+    echo "-s SLEEP : execution delay in seconds"
+    echo "-l LOGBUCKET : bucket for sending log file (required)"
+    echo "-j JOBID : jobs id"
+    exit "$1"
+}
+while getopts "s:l:j:" opt; do
+    case $opt in
+        s) SLEEP=$OPTARG;;  # execution delay in seconds
+        l) export LOGBUCKET=$OPTARG;;  # bucket for sending log file
+        j) export JOBID=$OPTARG;;  # job od
+        h) printHelpAndExit 0;;
+        [?]) printHelpAndExit 1;;
+        esac
+done
+
+sleep $SLEEP
+
+### send spot_failure message to S3
+if [ ! -f $JOBID.$SLEEP.spot_failure ]; then
+    touch $JOBID.$SLEEP.spot_failure
+    aws s3 cp $JOBID.$SLEEP.spot_failure s3://$LOGBUCKET/$JOBID.$SLEEP.spot_failure
+fi
+
+#echo "$LOGBUCKET / $JOBID"
+

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -349,7 +349,7 @@ EC2 Spot failure detection
 ##########################
 
 
-From Tibanna version 1.5.1, a cron job on the EC2 will regularly check for Spot Instance interruption notices issued by AWS (in case the workflow on a Spot instance). In such an event, the EC2 spot instance is going to be terminated by AWS and the workflow run will most likely fail. In this case Tibanna creates a file called ``<jobid>.spot_failure`` in the log bucket.
+From Tibanna version 1.6.0, a cron job on the EC2 will regularly check for Spot Instance interruption notices issued by AWS (in case the workflow on a Spot instance). In such an event, the EC2 spot instance is going to be terminated by AWS and the workflow run will most likely fail. In this case Tibanna creates a file called ``<jobid>.spot_failure`` in the log bucket.
 
 
 DEBUG tar ball

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -345,6 +345,12 @@ To Download the postrun json file manually, the following command also works.
     aws s3 cp s3://<tibanna_lob_bucket_name>/<jobid>.postrun.json .
 
 
+EC2 Spot failure detection
+##########################
+
+
+From Tibanna version 1.5.1, a cron job on the EC2 will regularly check for Spot Instance interruption notices issued by AWS (in case the workflow on a Spot instance). In such an event, the EC2 spot instance is going to be terminated by AWS and the workflow run will most likely fail. In this case Tibanna creates a file called ``<jobid>.spot_failure`` in the log bucket.
+
 
 DEBUG tar ball
 ##############

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.5.1"
+__version__ = "1.6.0"

--- a/tibanna/iam_utils.py
+++ b/tibanna/iam_utils.py
@@ -147,7 +147,7 @@ class IAM(object):
         check_task_custom_policy_types = ['cloudwatch_metric', 'cloudwatch', 'bucket', 'ec2_desc',
                                           'termination', 'dynamodb', 'pricing', 'vpc']
         update_cost_custom_policy_types = ['bucket', 'executions', 'dynamodb', 'pricing', 'vpc']
-        arnlist = {'ec2': [self.policy_arn(_) for _ in ['bucket', 'cloudwatch_metric']] +
+        arnlist = {'ec2': [self.policy_arn(_) for _ in ['bucket', 'cloudwatch_metric', 'ec2_desc']] +
                           ['arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly'],
                    # 'stepfunction': [self.policy_arn(_) for _ in ['lambdainvoke']],
                    'stepfunction': ['arn:aws:iam::aws:policy/service-role/AWSLambdaRole'],
@@ -398,7 +398,8 @@ class IAM(object):
                     "Action": [
                         "ec2:DescribeInstances",
                         "ec2:DescribeInstanceStatus",
-                        "ec2:DescribeSpotPriceHistory"
+                        "ec2:DescribeSpotPriceHistory",
+                        "ec2:DescribeSpotInstanceRequests"
                     ],
                     "Resource": "*"
                 }


### PR DESCRIPTION
If a workflow is run on a spot instance, a new cron job will regularly check for the AWS termination notice in the EC2 metadata. If the termination notice is detected, a file `JOBID.spot_failure` is created in the S3 log bucket.

The preinstalled `ec2metadata` package is old and does not provide the required `/spot/instance-action` endpoint. We therefore check directly for that meta data using the instance metadata service (v1) as described here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

The functionality of the cron script has been tested using an EC2 metadata mocking library.