### PR TITLE
Add run_args to specify additional command line arguments

### DIFF
--- a/awsf3-docker/run.sh
+++ b/awsf3-docker/run.sh
@@ -216,11 +216,11 @@ then
     exl echo "## Initializing Caper"
     # Since we are running caper in LOCAL_WFDIR we don't need to set local-loc-dir in the caper config
     exl caper init local
-    exl caper run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE
+    exl caper run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE $RUN_ARGS
     handle_error $?
   else # default to cromwell
     exl echo "## Using the Cromwell workflow engine"
-    exl java -jar /usr/local/bin/cromwell.jar run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE
+    exl java -jar /usr/local/bin/cromwell.jar run $MAIN_WDL -i $cwd0/$INPUT_YML_FILE -m $LOGJSONFILE $RUN_ARGS
     handle_error $?
   fi
 elif [[ $LANGUAGE == 'wdl_draft2' ]]  # 'wdl' defaults to 'wdl_v1'
@@ -249,7 +249,7 @@ else
   # cwltool cannot recognize symlinks and end up copying output from tmp directory intead of moving.
   # To prevent this, use the original directory name here.
   mkdir -p $LOCAL_WF_TMPDIR_CWL
-  exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
+  exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
   handle_error $?
 fi
 cd $cwd0

--- a/awsf3/utils.py
+++ b/awsf3/utils.py
@@ -186,6 +186,7 @@ def create_env_def_file(env_filename, runjson, language):
             f_env.write("export WDL_URL={}\n".format(app.wdl_url))
             f_env.write("export MAIN_WDL={}\n".format(app.main_wdl))
             f_env.write("export WORKFLOW_ENGINE={}\n".format(app.workflow_engine))
+            f_env.write("export RUN_ARGS={}\n".format(app.run_args))
             f_env.write("export WDL_FILES=\"{}\"\n".format(' '.join(app.other_wdl_files.split(','))))
         elif language == 'snakemake':
             f_env.write("export SNAKEMAKE_URL={}\n".format(app.snakemake_url))
@@ -200,6 +201,7 @@ def create_env_def_file(env_filename, runjson, language):
             f_env.write("export CWL_URL={}\n".format(app.cwl_url))
             f_env.write("export MAIN_CWL={}\n".format(app.main_cwl))
             f_env.write("export CWL_FILES=\"{}\"\n".format(' '.join(app.other_cwl_files.split(','))))
+            f_env.write("export RUN_ARGS={}\n".format(app.run_args))
         # other env variables
         env_preserv_str = ''
         docker_env_str = ''

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -205,7 +205,7 @@ Other pipeline-related fields
     - For WDL, it is a required field. For CWL, the language field can be omitted.
 
 :run_args:
-    - Optional, available for tibanna >= ``1.8.0``
+    - Optional, available for tibanna > ``1.9.1``
     - Additional command line arguments that are passed to the ``cwltool``/``cromwell.jar run``/``caper run`` commands.
 
 

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -204,6 +204,10 @@ Other pipeline-related fields
     - 'cwl_v1', 'cwl_draft3' (tibanna < ``1.0.0`` only) or 'wdl' (='wdl_v1' for backward compatibility) or 'wdl_draft2' or 'wdl_v1' (tibanna >= ``1.0.0``)
     - For WDL, it is a required field. For CWL, the language field can be omitted.
 
+:run_args:
+    - Optional, available for tibanna >= ``1.8.0``
+    - Additional command line arguments that are passed to the ``cwltool``/``cromwell.jar run``/``caper run`` commands.
+
 
 Input data specification
 ########################

--- a/docs/wdl.rst
+++ b/docs/wdl.rst
@@ -4,6 +4,6 @@ Workflow Description Language (WDL)
 
 Tibanna version < ``1.0.0`` supports WDL draft-2, through Cromwell binary version 35. Tibanna version >= ``1.0.0`` supports both WDL draft-2 and v1.0, through Cromwell binary version 35 and 53, respectively. This is because some of our old WDL pipelines written in draft-2 version no longer works with the new Cromwell version and we wanted to ensure the backward compatibility. But if you want to use WDL draft-2, specify ``"language": "wdl_draft2"`` instead of ``"language": "wdl"`` which defaults to WDL v1.0.
 
-Tibanna version >= ``1.7.0`` supports (Caper_) in addition to Cromwell. If you would like to use Caper, add ``"workflow_engine": "caper"`` to the Tibanna job description. Cromwell is the default.
+Tibanna version >= ``1.7.0`` supports (Caper_) in addition to Cromwell. If you would like to use Caper, add ``"workflow_engine": "caper"`` to the Tibanna job description. Cromwell is the default. If you want to pass additional parameters to Cromwell or Caper, you can specify ``run_args`` in the Tibanna job description, e.g., ``"run_args": "--docker"`` will add the docker flag to the Cromwell/Caper ``run`` command.
 
 .. _Caper: https://github.com/ENCODE-DCC/caper

--- a/tests/awsf3/test_utils.py
+++ b/tests/awsf3/test_utils.py
@@ -39,6 +39,7 @@ def test_create_env_def_file_cwl():
     runjson_dict = {'Job': {'App': {'language': 'cwl_v1',
                                     'cwl_url': 'someurl',
                                     'main_cwl': 'somecwl',
+                                    'run_args': '',
                                     'other_cwl_files': 'othercwl1,othercwl2'},
                             'Input': {'Env': {'SOME_ENV': '1234'}},
                             'Output': {'output_bucket_directory': 'somebucket'},
@@ -54,6 +55,7 @@ def test_create_env_def_file_cwl():
                      'export CWL_URL=someurl\n'
                      'export MAIN_CWL=somecwl\n'
                      'export CWL_FILES="othercwl1 othercwl2"\n'
+                     'export RUN_ARGS=\n'
                      'export SOME_ENV=1234\n'
                      'export PRESERVED_ENV_OPTION="--preserve-environment SOME_ENV "\n'
                      'export DOCKER_ENV_OPTION="-e SOME_ENV "\n')
@@ -70,6 +72,7 @@ def test_create_env_def_file_wdl_v1():
                                     'wdl_url': 'someurl',
                                     'main_wdl': 'somewdl',
                                     'workflow_engine': 'cromwell',
+                                    'run_args': '',
                                     'other_wdl_files': 'otherwdl1,otherwdl2'},
                             'Input': {'Env': {}},
                             'Output': {'output_bucket_directory': 'somebucket'},
@@ -85,6 +88,7 @@ def test_create_env_def_file_wdl_v1():
                      'export WDL_URL=someurl\n'
                      'export MAIN_WDL=somewdl\n'
                      'export WORKFLOW_ENGINE=cromwell\n'
+                     'export RUN_ARGS=\n'
                      'export WDL_FILES="otherwdl1 otherwdl2"\n'
                      'export PRESERVED_ENV_OPTION=""\n'
                      'export DOCKER_ENV_OPTION=""\n')
@@ -101,6 +105,7 @@ def test_create_env_def_file_wdl_draft2():
                                     'wdl_url': 'someurl',
                                     'main_wdl': 'somewdl',
                                     'workflow_engine': 'cromwell',
+                                    'run_args': '',
                                     'other_wdl_files': 'otherwdl1,otherwdl2'},
                             'Input': {'Env': {}},
                             'Output': {'output_bucket_directory': 'somebucket'},
@@ -116,6 +121,7 @@ def test_create_env_def_file_wdl_draft2():
                      'export WDL_URL=someurl\n'
                      'export MAIN_WDL=somewdl\n'
                      'export WORKFLOW_ENGINE=cromwell\n'
+                     'export RUN_ARGS=\n'
                      'export WDL_FILES="otherwdl1 otherwdl2"\n'
                      'export PRESERVED_ENV_OPTION=""\n'
                      'export DOCKER_ENV_OPTION=""\n')
@@ -132,6 +138,7 @@ def test_create_env_def_file_wdl():
                                     'wdl_url': 'someurl',
                                     'main_wdl': 'somewdl',
                                     'workflow_engine': 'cromwell',
+                                    'run_args': '',
                                     'other_wdl_files': 'otherwdl1,otherwdl2'},
                             'Input': {'Env': {}},
                             'Output': {'output_bucket_directory': 'somebucket'},
@@ -147,6 +154,7 @@ def test_create_env_def_file_wdl():
                      'export WDL_URL=someurl\n'
                      'export MAIN_WDL=somewdl\n'
                      'export WORKFLOW_ENGINE=cromwell\n'
+                     'export RUN_ARGS=\n'
                      'export WDL_FILES="otherwdl1 otherwdl2"\n'
                      'export PRESERVED_ENV_OPTION=""\n'
                      'export DOCKER_ENV_OPTION=""\n')

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.8.0"
+__version__ = "1.7.2b1"

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.9.1"
+__version__ = "1.9.2"

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.7.0"
+__version__ = "1.8.0"

--- a/tibanna/awsem.py
+++ b/tibanna/awsem.py
@@ -70,7 +70,7 @@ class AwsemRunJsonLog(SerializableObject):
 class AwsemRunJsonApp(SerializableObject):
     def __init__(self, App_name=None, App_version=None, language=None,
                  cwl_url=None, main_cwl=None, other_cwl_files=None,
-                 wdl_url=None, main_wdl=None, other_wdl_files=None, workflow_engine=None,
+                 wdl_url=None, main_wdl=None, other_wdl_files=None, workflow_engine=None, run_args=None,
                  container_image=None, command=None,
                  snakemake_url=None, main_snakemake=None, other_snakemake_files=None):
         self.App_name = App_name
@@ -83,6 +83,7 @@ class AwsemRunJsonApp(SerializableObject):
         self.main_wdl = main_wdl
         self.other_wdl_files = other_wdl_files
         self.workflow_engine = workflow_engine
+        self.run_args = run_args
         self.container_image = container_image
         self.command = command
         self.snakemake_url = snakemake_url

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -171,6 +171,8 @@ class Args(SerializableObject):
                 self.wdl_directory_url = ''
             if not hasattr(self, 'workflow_engine'):
                 self.workflow_engine = 'cromwell'
+            if not hasattr(self, 'run_args'):
+                self.run_args = ''
             if not self.wdl_directory_local and not self.wdl_directory_url:
                 errmsg = "either %s or %s must be provided in args" % ('wdl_directory_url', 'wdl_directory_local')
                 raise MissingFieldInInputJsonException(errmsg)
@@ -203,6 +205,8 @@ class Args(SerializableObject):
                 self.cwl_directory_local = ''
             if not hasattr(self, 'cwl_directory_url'):
                 self.cwl_directory_url = ''
+            if not hasattr(self, 'run_args'):
+                self.run_args = ''
             if not self.cwl_directory_local and not self.cwl_directory_url:
                 errmsg = "either %s or %s must be provided in args" % ('cwl_directory_url', 'cwl_directory_local')
                 raise MissingFieldInInputJsonException(errmsg)
@@ -580,7 +584,8 @@ class Execution(object):
                 'main_wdl': args.wdl_main_filename,
                 'other_wdl_files': ','.join(args.wdl_child_filenames),
                 'wdl_url': args.wdl_directory_url,
-                'workflow_engine': args.workflow_engine
+                'workflow_engine': args.workflow_engine,
+                'run_args': args.run_args
             })
         elif args.language == 'snakemake':
             app.update({
@@ -600,6 +605,7 @@ class Execution(object):
                 'main_cwl': args.cwl_main_filename,
                 'other_cwl_files': ','.join(args.cwl_child_filenames),
                 'cwl_url': args.cwl_directory_url,
+                'run_args': args.run_args
             })
         pre.update({'Job': {'JOBID': jobid,
                             'App': app,


### PR DESCRIPTION
With this change, additional command line arguments can be specified in the tibanna job description that are passed to the `cwltool`, `cromwell run`, `caper run` commands.

This is necessary, e.g., for the ChipSeq pipeline that only runs using `caper run ... --docker`. In this case we can now specify `"run_args": "--docker"` in the job description.