### PR TITLE
Pass custom-net option to cwltool

### DIFF
--- a/awsf3-docker/run.sh
+++ b/awsf3-docker/run.sh
@@ -299,8 +299,9 @@ else
   fi
   # cwltool cannot recognize symlinks and end up copying output from tmp directory intead of moving.
   # To prevent this, use the original directory name here.
+  exl echo "cwltool --enable-dev --non-strict --no-read-only --no-match-user --custom-net host --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE"
   mkdir -p $LOCAL_WF_TMPDIR_CWL
-  exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
+  exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user --custom-net host --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
   handle_error $?
 fi
 cd $cwd0

--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.9.0"
+__version__ = "1.9.1"


### PR DESCRIPTION
This PR adds the `--custom-net host` option to the `cwltool` command, so that the docker container that is started by `cwltool` uses the network configuration of the host.