### PR TITLE
Switch lambdas to Python 3.8 runtime

### DIFF
--- a/tibanna/_version.py
+++ b/tibanna/_version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "1.9.1"
+__version__ = "1.9.2"

--- a/tibanna/lambdas/check_task_awsem.py
+++ b/tibanna/lambdas/check_task_awsem.py
@@ -7,7 +7,7 @@ config = {
     'function_handler': 'handler',
     'handler': 'service.handler',
     'region': AWS_REGION,
-    'runtime': 'python3.6',
+    'runtime': 'python3.8',
     'role': 'tibanna_lambda_init_role',
     'description': 'check status of AWSEM run by interegating appropriate files on S3 ',
     'timeout': 300,

--- a/tibanna/lambdas/run_task_awsem.py
+++ b/tibanna/lambdas/run_task_awsem.py
@@ -8,7 +8,7 @@ config = {
     'function_handler': 'handler',
     'handler': 'service.handler',
     'region': AWS_REGION,
-    'runtime': 'python3.6',
+    'runtime': 'python3.8',
     'role': 'tibanna_lambda_init_role',
     'description': 'launch an ec2 instance',
     'timeout': 300,

--- a/tibanna/lambdas/update_cost_awsem.py
+++ b/tibanna/lambdas/update_cost_awsem.py
@@ -8,7 +8,7 @@ config = {
     'function_handler': 'handler',
     'handler': 'service.handler',
     'region': AWS_REGION,
-    'runtime': 'python3.6',
+    'runtime': 'python3.8',
     'role': 'tibanna_lambda_init_role',
     'description': 'update costs of a workflow run',
     'timeout': 300,


### PR DESCRIPTION
Switch lambdas to Python 3.8 runtime. No issues when running a test workflow.