### PR TITLE
Use Cloudwatch agent to collect metrics

### DIFF
--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -186,19 +186,10 @@ apt install -y wget
 wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
 sudo dpkg -i -E ./amazon-cloudwatch-agent.deb
 # If we want to collect new metrics, the following file has to be modified
-#wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_config.json
-wget https://raw.githubusercontent.com/4dn-dcic/tibanna/cloudwatch-agent/awsf3/cloudwatch_agent_config.json
+wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_config.json
 mv ./cloudwatch_agent_config.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
 # This starts the agent with the downloaded configuration file
 sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
-
-
-# apt install -y unzip libwww-perl libdatetime-perl
-# curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
-# unzip CloudWatchMonitoringScripts-1.2.2.zip && rm CloudWatchMonitoringScripts-1.2.2.zip && cd aws-scripts-mon
-# echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-path=/data1/ --from-cron" > ~/recurring.jobs
-# echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util --disk-space-used --disk-path=/ --from-cron" >> ~/recurring.jobs
-
 
 # Set up cronjob to monitor AWS spot instance termination notice.
 # Works only in deployed Tibanna version >=1.6.0 since the ec2 needed more permissions to call `aws ec2 describe-spot-instance-requests`

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -177,16 +177,27 @@ mv $LOGFILE1 $LOGFILE2
 export LOGFILE=$LOGFILE2
 
 
-# set up cronjob for cloudwatch metrics for memory, disk space and CPU utilization
 exl echo
-exl echo "## Turning on cloudwatch metrics for memory and disk space"
+exl echo "## Installing and activating Cloudwatch agent to collect metrics"
 cwd0=$(pwd)
 cd ~
-apt install -y unzip libwww-perl libdatetime-perl
-curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
-unzip CloudWatchMonitoringScripts-1.2.2.zip && rm CloudWatchMonitoringScripts-1.2.2.zip && cd aws-scripts-mon
-echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-path=/data1/ --from-cron" > ~/recurring.jobs
-echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util --disk-space-used --disk-path=/ --from-cron" >> ~/recurring.jobs
+
+apt install -y wget
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+sudo dpkg -i -E ./amazon-cloudwatch-agent.deb
+# If we want to collect new metrics, the following file has to be modified
+wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_confg.json
+mv ./cloudwatch_agent_confg.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
+# This starts the agent with the downloaded configuration file
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
+
+
+# apt install -y unzip libwww-perl libdatetime-perl
+# curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O
+# unzip CloudWatchMonitoringScripts-1.2.2.zip && rm CloudWatchMonitoringScripts-1.2.2.zip && cd aws-scripts-mon
+# echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-path=/data1/ --from-cron" > ~/recurring.jobs
+# echo "*/1 * * * * ~/aws-scripts-mon/mon-put-instance-data.pl --disk-space-util --disk-space-used --disk-path=/ --from-cron" >> ~/recurring.jobs
+
 
 # Set up cronjob to monitor AWS spot instance termination notice.
 # Works only in deployed Tibanna version >=1.6.0 since the ec2 needed more permissions to call `aws ec2 describe-spot-instance-requests`

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -188,7 +188,7 @@ sudo dpkg -i -E ./amazon-cloudwatch-agent.deb
 # If we want to collect new metrics, the following file has to be modified
 #wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_config.json
 wget https://raw.githubusercontent.com/4dn-dcic/tibanna/cloudwatch-agent/awsf3/cloudwatch_agent_config.json
-mv ./cloudwatch_agent_confg.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
+mv ./cloudwatch_agent_config.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
 # This starts the agent with the downloaded configuration file
 sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
 

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -186,7 +186,8 @@ apt install -y wget
 wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
 sudo dpkg -i -E ./amazon-cloudwatch-agent.deb
 # If we want to collect new metrics, the following file has to be modified
-wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_confg.json
+#wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_config.json
+wget https://raw.githubusercontent.com/4dn-dcic/tibanna/cloudwatch-agent/awsf3/cloudwatch_agent_config.json
 mv ./cloudwatch_agent_confg.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
 # This starts the agent with the downloaded configuration file
 sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -1,6 +1,6 @@
 {
 	"agent": {
-		"metrics_collection_interval": 10,
+		"metrics_collection_interval": 60,
 		"run_as_user": "root"
 	},
 	"metrics": {
@@ -18,45 +18,56 @@
 		"metrics_collected": {
 			"cpu": {
 				"measurement": [
-					"cpu_usage_idle",
-					"cpu_usage_iowait",
-					"cpu_usage_user",
-					"cpu_usage_system"
+					"usage_idle",
+					"usage_iowait",
+					"usage_system"
 				],
-				"metrics_collection_interval": 10,
-				"totalcpu": false
+				"metrics_collection_interval": 60,
+				"totalcpu": true
 			},
 			"disk": {
 				"measurement": [
+                    "free",
+                    "total",
+                    "used",
 					"used_percent",
 					"inodes_free"
 				],
-				"metrics_collection_interval": 10,
+				"metrics_collection_interval": 60,
 				"resources": [
 					"*"
 				]
 			},
 			"diskio": {
 				"measurement": [
-					"io_time"
+					"io_time",
+                    "read_bytes",
+                    "iops_in_progress"
 				],
-				"metrics_collection_interval": 10,
+				"metrics_collection_interval": 60,
 				"resources": [
 					"*"
 				]
 			},
 			"mem": {
 				"measurement": [
-					"mem_used_percent"
+					"used_percent",
+                    "used",
+                    "available_percent",
+                    "available"
 				],
-				"metrics_collection_interval": 10
+				"metrics_collection_interval": 60
 			},
-			"swap": {
+            "net": {
 				"measurement": [
-					"swap_used_percent"
+					"bytes_sent",
+                    "bytes_recv"
 				],
-				"metrics_collection_interval": 10
-			}
+				"metrics_collection_interval": 60,
+				"resources": [
+					"*"
+				]
+			},
 		}
 	}
 }

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -1,7 +1,9 @@
 {
 	"agent": {
 		"metrics_collection_interval": 60,
-		"run_as_user": "root"
+		"run_as_user": "root",
+        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+        "debug": true,
 	},
 	"metrics": {
 		"aggregation_dimensions": [
@@ -9,12 +11,6 @@
 				"InstanceId"
 			]
 		],
-		"append_dimensions": {
-			"AutoScalingGroupName": "${aws:AutoScalingGroupName}",
-			"ImageId": "${aws:ImageId}",
-			"InstanceId": "${aws:InstanceId}",
-			"InstanceType": "${aws:InstanceType}"
-		},
 		"metrics_collected": {
 			"cpu": {
 				"measurement": [

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -34,7 +34,7 @@
 				],
 				"metrics_collection_interval": 60,
 				"resources": [
-					"*"
+					"/mnt/data1"
 				]
 			},
 			"diskio": {
@@ -45,7 +45,7 @@
 				],
 				"metrics_collection_interval": 60,
 				"resources": [
-					"*"
+					"/mnt/data1"
 				]
 			},
 			"mem": {

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -1,6 +1,6 @@
 {
 	"agent": {
-		"metrics_collection_interval": 60,
+		"metrics_collection_interval": 10,
 		"run_as_user": "root"
 	},
 	"metrics": {
@@ -23,7 +23,7 @@
 					"cpu_usage_user",
 					"cpu_usage_system"
 				],
-				"metrics_collection_interval": 60,
+				"metrics_collection_interval": 10,
 				"totalcpu": false
 			},
 			"disk": {
@@ -31,7 +31,7 @@
 					"used_percent",
 					"inodes_free"
 				],
-				"metrics_collection_interval": 60,
+				"metrics_collection_interval": 10,
 				"resources": [
 					"*"
 				]
@@ -40,7 +40,7 @@
 				"measurement": [
 					"io_time"
 				],
-				"metrics_collection_interval": 60,
+				"metrics_collection_interval": 10,
 				"resources": [
 					"*"
 				]
@@ -49,13 +49,13 @@
 				"measurement": [
 					"mem_used_percent"
 				],
-				"metrics_collection_interval": 60
+				"metrics_collection_interval": 10
 			},
 			"swap": {
 				"measurement": [
 					"swap_used_percent"
 				],
-				"metrics_collection_interval": 60
+				"metrics_collection_interval": 10
 			}
 		}
 	}

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -45,7 +45,7 @@
 				],
 				"metrics_collection_interval": 60,
 				"resources": [
-					"/mnt/data1"
+					"*"
 				]
 			},
 			"mem": {

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -3,7 +3,7 @@
 		"metrics_collection_interval": 60,
 		"run_as_user": "root",
         "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
-        "debug": true,
+        "debug": true
 	},
 	"metrics": {
 		"aggregation_dimensions": [
@@ -63,7 +63,7 @@
 				"resources": [
 					"*"
 				]
-			},
+			}
 		}
 	}
 }

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -11,6 +11,9 @@
 				"InstanceId"
 			]
 		],
+        "append_dimensions": {
+			"InstanceId": "${aws:InstanceId}"
+		},
 		"metrics_collected": {
 			"cpu": {
 				"measurement": [

--- a/awsf3/cloudwatch_agent_config.json
+++ b/awsf3/cloudwatch_agent_config.json
@@ -1,0 +1,62 @@
+{
+	"agent": {
+		"metrics_collection_interval": 60,
+		"run_as_user": "root"
+	},
+	"metrics": {
+		"aggregation_dimensions": [
+			[
+				"InstanceId"
+			]
+		],
+		"append_dimensions": {
+			"AutoScalingGroupName": "${aws:AutoScalingGroupName}",
+			"ImageId": "${aws:ImageId}",
+			"InstanceId": "${aws:InstanceId}",
+			"InstanceType": "${aws:InstanceType}"
+		},
+		"metrics_collected": {
+			"cpu": {
+				"measurement": [
+					"cpu_usage_idle",
+					"cpu_usage_iowait",
+					"cpu_usage_user",
+					"cpu_usage_system"
+				],
+				"metrics_collection_interval": 60,
+				"totalcpu": false
+			},
+			"disk": {
+				"measurement": [
+					"used_percent",
+					"inodes_free"
+				],
+				"metrics_collection_interval": 60,
+				"resources": [
+					"*"
+				]
+			},
+			"diskio": {
+				"measurement": [
+					"io_time"
+				],
+				"metrics_collection_interval": 60,
+				"resources": [
+					"*"
+				]
+			},
+			"mem": {
+				"measurement": [
+					"mem_used_percent"
+				],
+				"metrics_collection_interval": 60
+			},
+			"swap": {
+				"measurement": [
+					"swap_used_percent"
+				],
+				"metrics_collection_interval": 60
+			}
+		}
+	}
+}

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -480,6 +480,7 @@ To visualize the html report the URL structure is: ``https://<log-bucket>.s3.ama
 
 Starting with ``1.0.0``, the metrics plot will include per-process CPU and memory profiles retrieved from the top command reports at a 1-minute interval. Additional files `top_cpu.tsv` and `top_mem.tsv` will also be created under the same folder ``<jobid>.metrics``.
 
+From version ``2.1.0``, the metrics that are send to cloud watch are defined here: ``https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_config.json``. Note that not every metric that is available in cloud watch is displayed in the report created by ``plot_metrics``.
 
 
 Basic Command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.0.0"
+version = "2.0.1"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.1.0b0"
+version = "2.0.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.0.1"
+version = "2.1.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.0.0"
+version = "2.1.0b0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna/cw_utils.py
+++ b/tibanna/cw_utils.py
@@ -13,6 +13,7 @@ from .vars import (
 )
 from datetime import datetime
 from datetime import timedelta
+import json, math
 
 
 logger = create_logger(__name__)
@@ -121,9 +122,11 @@ class TibannaResource(object):
             'max_disk_space_used_GB': (max_disk_space_used_GB_chunks_all_pts, 1),
             'max_mem_utilization_percent': (max_mem_utilization_percent_chunks_all_pts, 1),
             'max_disk_space_utilization_percent': (max_disk_space_utilization_percent_chunks_all_pts, 1),
-            'max_cpu_utilization_percent': (max_cpu_utilization_percent_chunks_all_pts, 5)
+            'max_cpu_utilization_percent': (max_cpu_utilization_percent_chunks_all_pts, 1)
         }
 
+        # print(json.dumps(input_dict, indent=4))
+        # return
         self.list_files.extend(self.write_top_tsvs(directory, top_content))
         self.list_files.append(self.write_tsv(directory, **input_dict))
         self.list_files.append(self.write_metrics(instance_type, directory))
@@ -213,8 +216,8 @@ class TibannaResource(object):
     # functions that returns all points
     def max_memory_utilization_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='System/Linux',
-            MetricName='MemoryUtilization',
+            Namespace='CWAgent',
+            MetricName='mem_used_percent',
             Dimensions=[{
                 'Name': 'InstanceId', 'Value': self.instance_id
             }],
@@ -229,8 +232,8 @@ class TibannaResource(object):
 
     def max_memory_used_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='System/Linux',
-            MetricName='MemoryUsed',
+            Namespace='CWAgent',
+            MetricName='mem_used',
             Dimensions=[{
                 'Name': 'InstanceId', 'Value': self.instance_id
             }],
@@ -238,15 +241,15 @@ class TibannaResource(object):
             Statistics=['Maximum'],
             StartTime=self.starttime,
             EndTime=self.endtime,
-            Unit='Megabytes'
+            Unit='Bytes'
         )
-        pts = [(r['Maximum'], r['Timestamp']) for r in res['Datapoints']]
+        pts = [(r['Maximum']/math.pow(1024, 2), r['Timestamp']) for r in res['Datapoints']] # get values in MB
         return[p[0] for p in sorted(pts, key=lambda x: x[1])]
 
     def min_memory_available_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='System/Linux',
-            MetricName='MemoryAvailable',
+            Namespace='CWAgent',
+            MetricName='mem_available',
             Dimensions=[{
                 'Name': 'InstanceId', 'Value': self.instance_id
             }],
@@ -254,19 +257,19 @@ class TibannaResource(object):
             Statistics=['Minimum'],
             StartTime=self.starttime,
             EndTime=self.endtime,
-            Unit='Megabytes'
+            Unit='Bytes'
         )
-        pts = [(r['Minimum'], r['Timestamp']) for r in res['Datapoints']]
+        pts = [(r['Minimum']/math.pow(1024, 2), r['Timestamp']) for r in res['Datapoints']] # get values in MB
         return[p[0] for p in sorted(pts, key=lambda x: x[1])]
 
     def max_cpu_utilization_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='AWS/EC2',
-            MetricName='CPUUtilization',
+            Namespace='CWAgent',
+            MetricName='cpu_usage_system',
             Dimensions=[{
                 'Name': 'InstanceId', 'Value': self.instance_id
             }],
-            Period=60*5,
+            Period=60,
             Statistics=['Maximum'],
             StartTime=self.starttime,
             EndTime=self.endtime,
@@ -277,13 +280,11 @@ class TibannaResource(object):
 
     def max_disk_space_utilization_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='System/Linux',
-            MetricName='DiskSpaceUtilization',
-            Dimensions=[
-                {'Name': 'InstanceId', 'Value': self.instance_id},
-                {'Name': 'MountPath', 'Value': EBS_MOUNT_POINT},
-                {'Name': 'Filesystem', 'Value': self.filesystem}
-            ],
+            Namespace='CWAgent',
+            MetricName='disk_used_percent',
+            Dimensions=[{
+              'Name': 'InstanceId', 'Value': self.instance_id
+            }],
             Period=60,
             Statistics=['Maximum'],
             StartTime=self.starttime,
@@ -295,26 +296,24 @@ class TibannaResource(object):
 
     def max_disk_space_used_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='System/Linux',
-            MetricName='DiskSpaceUsed',
-            Dimensions=[
-                {'Name': 'InstanceId', 'Value': self.instance_id},
-                {'Name': 'MountPath', 'Value': EBS_MOUNT_POINT},
-                {'Name': 'Filesystem', 'Value': self.filesystem}
-            ],
+            Namespace='CWAgent',
+            MetricName='disk_used',
+            Dimensions=[{
+              'Name': 'InstanceId', 'Value': self.instance_id
+            }],
             Period=60,
             Statistics=['Maximum'],
             StartTime=self.starttime,
             EndTime=self.endtime,
-            Unit='Gigabytes'
+            Unit='Bytes'
         )
-        pts = [(r['Maximum'], r['Timestamp']) for r in res['Datapoints']]
+        pts = [(r['Maximum']/math.pow(1024, 3), r['Timestamp']) for r in res['Datapoints']] # we want it in GB
         return[p[0] for p in sorted(pts, key=lambda x: x[1])]
 
     def max_ebs_read_used_all_pts(self):
         res = self.client.get_metric_statistics(
-            Namespace='AWS/EC2',
-            MetricName='EBSReadBytes',
+            Namespace='CWAgent',
+            MetricName='diskio_read_bytes',
             Dimensions=[{
                 'Name': 'InstanceId', 'Value': self.instance_id
             }],
@@ -752,7 +751,7 @@ class TibannaResource(object):
                   // X scale for CPU utilization that has interval size of 5 instead of 1
                   var xScale_cpu = d3.scaleLinear()
                       .domain([0, n_cpu]) // input
-                      .range([0, width*(n_cpu)*5/(n)]); // output
+                      .range([0, width*(n_cpu)/(n)]); // output
                   // Y scale will use the randomly generate number
                   var yScale = d3.scaleLinear()
                       .domain([0, 100]) // input

--- a/tibanna/cw_utils.py
+++ b/tibanna/cw_utils.py
@@ -746,7 +746,7 @@ class TibannaResource(object):
                   var xScale = d3.scaleLinear()
                       .domain([0, n]) // input
                       .range([0, width]); // output
-                  // X scale for CPU utilization that has interval size of 5 instead of 1
+                  // X scale for CPU utilization
                   var xScale_cpu = d3.scaleLinear()
                       .domain([0, n_cpu]) // input
                       .range([0, width*(n_cpu)/(n)]); // output

--- a/tibanna/cw_utils.py
+++ b/tibanna/cw_utils.py
@@ -125,8 +125,6 @@ class TibannaResource(object):
             'max_cpu_utilization_percent': (max_cpu_utilization_percent_chunks_all_pts, 1)
         }
 
-        # print(json.dumps(input_dict, indent=4))
-        # return
         self.list_files.extend(self.write_top_tsvs(directory, top_content))
         self.list_files.append(self.write_tsv(directory, **input_dict))
         self.list_files.append(self.write_metrics(instance_type, directory))

--- a/tibanna/iam_utils.py
+++ b/tibanna/iam_utils.py
@@ -161,7 +161,8 @@ class IAM(object):
                                                  'termination', 'dynamodb', 'pricing', 'vpc']
         update_cost_custom_policy_types = base + ['executions', 'dynamodb', 'pricing', 'vpc']
         arnlist = {'ec2': [self.policy_arn(_) for _ in base + ['cloudwatch_metric', 'ec2_desc']] +
-                          ['arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly'],
+                          ['arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly'] +
+                          ['arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy'],
                    # 'stepfunction': [self.policy_arn(_) for _ in ['lambdainvoke']],
                    'stepfunction': ['arn:aws:iam::aws:policy/service-role/AWSLambdaRole'],
                    self.run_task_lambda_name: [self.policy_arn(_) for _ in run_task_custom_policy_types] +


### PR DESCRIPTION
This PR removes the use of the deprecated CloudWatchMonitoringScripts and switches to Cloudwatch agent to collect metrics from the EC2.