### PR TITLE
SFN Timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.2.1"
+version = "2.2.2"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna/stepfunction.py
+++ b/tibanna/stepfunction.py
@@ -22,8 +22,8 @@ class StepFunctionUnicorn(object):
         },
         {
             "ErrorEquals": ["EC2InstanceLimitWaitException"],
-            "IntervalSeconds": 600,
-            "MaxAttempts": 1008,  # 1 wk
+            "IntervalSeconds": 300,  # dropped since we now parametrize on subnets, instance types
+            "MaxAttempts": 2016,  # still try for 1 week
             "BackoffRate": 1.0
         },
         lambda_error_retry_condition

--- a/tibanna/vars.py
+++ b/tibanna/vars.py
@@ -142,6 +142,7 @@ BASE_ARN = 'arn:aws:states:' + AWS_REGION + ':' + AWS_ACCOUNT_NUMBER + ':%s:%s'
 BASE_EXEC_ARN = 'arn:aws:states:' + AWS_REGION + ':' + AWS_ACCOUNT_NUMBER + ':execution:%s:%s'
 BASE_METRICS_URL = 'https://%s.s3.amazonaws.com/%s.metrics/metrics.html'
 
+
 def STEP_FUNCTION_ARN(sfn=TIBANNA_DEFAULT_STEP_FUNCTION_NAME):
     return BASE_ARN % ('stateMachine', sfn)
 


### PR DESCRIPTION
- Lower run_task timeout on retry so it will try a new instance/subnet combination sooner
- Adjust some logging and retry mechanisms around the DynamoDB API calls to ensure they go through, or at least more info comes from them when they do not work as expected
- Small PEP8