### PR TITLE
Support Graviton instances and switch to EC2 fleets

### DIFF
--- a/awsf3-docker/Dockerfile
+++ b/awsf3-docker/Dockerfile
@@ -35,25 +35,31 @@ RUN apt update -y && apt upgrade -y &&  apt install -y \
     libseccomp-dev \
     pkg-config \
     openjdk-8-jre-headless \
-    nodejs
+    nodejs \
+    gnupg \
+    lsb-release
 
 RUN ln -s /usr/bin/python3.8 /usr/bin/python
 #RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 WORKDIR /usr/local/bin
 
-# docker inside docker
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-    && apt-key fingerprint 0EBFCD88 \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-RUN apt-get update -y \
-    && apt-cache policy docker-ce \
-    && apt-get install -y docker-ce
+# install docker inside docker
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update
+RUN apt-get --assume-yes install docker-ce
 
 # singularity
-RUN wget https://golang.org/dl/go1.16.6.linux-amd64.tar.gz && \
-    tar -xzf go1.16.6.linux-amd64.tar.gz && \
-    rm go1.16.6.linux-amd64.tar.gz
+RUN ARCH="$(dpkg --print-architecture)" && \
+    wget "https://golang.org/dl/go1.16.6.linux-${ARCH}.tar.gz" && \
+    tar -xzf "go1.16.6.linux-${ARCH}.tar.gz" && \
+    rm "go1.16.6.linux-${ARCH}.tar.gz"
 RUN export SINGULARITY_VERSION=3.8.1 && \
     export PATH=/usr/local/bin/go/bin/:$PATH && \
     wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-ce-${SINGULARITY_VERSION}.tar.gz && \

--- a/awsf3-docker/run.sh
+++ b/awsf3-docker/run.sh
@@ -48,6 +48,7 @@ export TOPLATESTFILE=$LOCAL_OUTDIR/$JOBID.top_latest  # this one includes only t
 export INSTANCE_ID=$(ec2metadata --instance-id|cut -d' ' -f2)
 export INSTANCE_REGION=$(ec2metadata --availability-zone | sed 's/[a-z]$//')
 export INSTANCE_AVAILABILITY_ZONE=$(ec2metadata --availability-zone)
+export INSTANCE_TYPE=$(ec2metadata --instance-type)
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity| grep Account | sed 's/[^0-9]//g')
 export AWS_REGION=$INSTANCE_REGION  # this is for importing awsf3 package which imports tibanna package
 export LOCAL_OUTDIR_CWL=$MOUNT_DIR_PREFIX$LOCAL_OUTDIR

--- a/awsf3/aws_run_workflow_generic.sh
+++ b/awsf3/aws_run_workflow_generic.sh
@@ -182,8 +182,11 @@ exl echo "## Installing and activating Cloudwatch agent to collect metrics"
 cwd0=$(pwd)
 cd ~
 
+ARCHITECTURE="$(dpkg --print-architecture)"
+CW_AGENT_LINK="https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${ARCHITECTURE}/latest/amazon-cloudwatch-agent.deb"
 apt install -y wget
-wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+exl echo "Loading Cloudwatch Agent from ${CW_AGENT_LINK}"
+wget "${CW_AGENT_LINK}"
 sudo dpkg -i -E ./amazon-cloudwatch-agent.deb
 # If we want to collect new metrics, the following file has to be modified
 wget https://raw.githubusercontent.com/4dn-dcic/tibanna/master/awsf3/cloudwatch_agent_config.json

--- a/awsf3/utils.py
+++ b/awsf3/utils.py
@@ -348,6 +348,7 @@ def update_postrun_json_init(json_old, json_new):
     prj.Job.instance_id = os.getenv('INSTANCE_ID')
     prj.Job.filesystem = os.getenv('EBS_DEVICE')
     prj.Job.instance_availablity_zone = os.getenv('INSTANCE_AVAILABILITY_ZONE')
+    prj.Job.instance_type = os.getenv('INSTANCE_TYPE')
 
     # write to new json file
     write_postrun_json(json_new, prj)

--- a/docs/ami.rst
+++ b/docs/ami.rst
@@ -4,5 +4,5 @@ Amazon Machine Image
 
 Tibanna now uses a the Amazon Machine Images (AMI) ``ami-06e2266f85063aabc`` (``x86``) and ``ami-0e12894d2dc91ab8c`` (``Arm``), which are made public for ``us-east-1``. One can find them among Community AMIs. (Tibanna automatically finds and uses them, so no need to worry about it.)
 
-For regions that are not ``us-east-1``, a copy of the same AMI is publicly available (different AMI ID) and is auto-detected by Tibanna.
+For regions that are not ``us-east-1``, copies of these AMIs is publicly available (different AMI IDs) and are auto-detected by Tibanna.
 

--- a/docs/ami.rst
+++ b/docs/ami.rst
@@ -2,7 +2,7 @@
 Amazon Machine Image
 ====================
 
-Tibanna now uses a single Amazon Machine Image (AMI) ``ami-06e2266f85063aabc``, which is made public for ``us-east-1``. One can find them among Community AMIs. (Tibanna automatically finds and uses them, so no need to worry about it.)
+Tibanna now uses a the Amazon Machine Images (AMI) ``ami-06e2266f85063aabc`` (``x86``) and ``ami-0e12894d2dc91ab8c`` (``Arm``), which are made public for ``us-east-1``. One can find them among Community AMIs. (Tibanna automatically finds and uses them, so no need to worry about it.)
 
 For regions that are not ``us-east-1``, a copy of the same AMI is publicly available (different AMI ID) and is auto-detected by Tibanna.
 

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -588,9 +588,7 @@ The ``config`` field describes execution configuration.
     - available options :
 
       - ``fail`` (default)
-      - ``wait_and_retry`` (wait and retry with the same instance type again),
-      - ``other_instance_types`` top 10 cost-effective instance types will be tried in the order
-                                 (``mem`` and ``cpu`` must be set in order for this to work),
+      - ``wait_and_retry`` (wait and retry with the same instance type again.),
       - ``retry_without_spot`` (try with the same instance type but not a spot instance) : this option is applicable only when
         ``spot_instance`` is set to ```True``
 

--- a/docs/execution_json.rst
+++ b/docs/execution_json.rst
@@ -469,7 +469,12 @@ The ``config`` field describes execution configuration.
 :instance_type:
     - <instance_type>
     - This or ``mem`` and ``cpu`` are required if Benchmark is not available for a given workflow.
-    - If both ``instance_type`` and ``mem`` & ``cpu`` are specified, then ``instance_type`` is the first choice.
+    - ``instance_type`` can be a string (e.g.,  ``t3.micro``) or a list (e.g., ``[t3.micro, t3.small]``). If ``spot_instance``
+      is enabled, Tibanna will run the workflow on the instance with the highest available capacity. If ``spot_instance``
+      is disabled, it will run the workflow on the cheapest instance in the list.
+    - If both ``instance_type`` and ``mem`` & ``cpu`` are specified, Tibanna internally creates a list of instances that
+      are directly specified in ``instance_type`` and instances that satisfy the ``mem`` & ``cpu`` requirement. One instance is chosen
+      according to the rules above to run the workflow.
 
 :mem:
     - <memory_in_gb>

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,6 +19,10 @@ Version updates
 
 .. _releases: https://github.com/4dn-dcic/tibanna/releases
 
+  **Nov 16, 2022** The latest version is now 2.2.3_.
+    - Tibanna now supports AWS Graviton-based instances.
+
+
   **Mar 10, 2022** The latest version is now 2.0.0_.
     - The default Python version for Tibanna is now 3.8 (or 3.7). Python 3.6 is no longer supported.
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,8 +19,9 @@ Version updates
 
 .. _releases: https://github.com/4dn-dcic/tibanna/releases
 
-  **Nov 16, 2022** The latest version is now 2.2.3_.
+  **Nov 18, 2022** The latest version is now 2.3.0_.
     - Tibanna now supports AWS Graviton-based instances.
+    - The instance type configuration now allows single instances (e.g., ``t3.micro``) and lists (e.g., ``[t3.micro, t3.small]``). If ``spot_instance`` is enabled, Tibanna will run the workflow on the instance with the highest available capacity. If ``spot_instance`` is disabled, it will run the workflow on the cheapest instance in the list.
 
 
   **Mar 10, 2022** The latest version is now 2.0.0_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.2.4"
+version = "2.3.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "2.2.3"
+version = "2.2.3b1"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish-docker
+++ b/scripts/publish-docker
@@ -4,5 +4,6 @@
 export BUILD_LOG=/tmp/build-log
 export VERSION=$(python -c 'from tibanna._version import __version__; print(__version__)')
 export AWSF_IMAGE=$(python -c 'from tibanna.vars import DEFAULT_AWSF_IMAGE; print(DEFAULT_AWSF_IMAGE)')
-docker build -t $AWSF_IMAGE --build-arg version=$VERSION awsf3-docker/ > $BUILD_LOG
-docker push $AWSF_IMAGE
+# Your local docker driver needs to support the multiple platforms feature
+docker buildx build --push --platform linux/amd64,linux/arm64 -t $AWSF_IMAGE --build-arg version=$VERSION awsf3-docker/ > $BUILD_LOG
+

--- a/test_json/unicorn/medium_nonspot.postrun.json
+++ b/test_json/unicorn/medium_nonspot.postrun.json
@@ -53,6 +53,7 @@
         "status": "0",
         "filesystem": "/dev/nvme1n1",
         "instance_id": "i-01769a822e5dbb407",
+        "instance_type": "t3.medium",
         "instance_availablity_zone": "us-east-1b",
         "total_input_size": "12K",
         "total_output_size": "36K",

--- a/test_json/unicorn/small_spot.postrun.json
+++ b/test_json/unicorn/small_spot.postrun.json
@@ -53,6 +53,7 @@
         "status": "0",
         "filesystem": "/dev/nvme1n1",
         "instance_id": "i-01769a822e5dbb407",
+        "instance_type": "t3.small",
         "instance_availablity_zone": "us-east-1b",
         "total_input_size": "12K",
         "total_output_size": "36K",

--- a/test_json/unicorn/small_spot_gp3_iops.postrun.json
+++ b/test_json/unicorn/small_spot_gp3_iops.postrun.json
@@ -53,6 +53,7 @@
         "status": "0",
         "filesystem": "/dev/nvme1n1",
         "instance_id": "i-01769a822e5dbb407",
+        "instance_type": "t3.small",
         "instance_availablity_zone": "us-east-1b",
         "total_input_size": "12K",
         "total_output_size": "36K",

--- a/test_json/unicorn/small_spot_gp3_iops_throughput.postrun.json
+++ b/test_json/unicorn/small_spot_gp3_iops_throughput.postrun.json
@@ -53,6 +53,7 @@
         "status": "0",
         "filesystem": "/dev/nvme1n1",
         "instance_id": "i-01769a822e5dbb407",
+        "instance_type": "t3.small",
         "instance_availablity_zone": "us-east-1b",
         "total_input_size": "12K",
         "total_output_size": "36K",

--- a/test_json/unicorn/small_spot_io2_iops.postrun.json
+++ b/test_json/unicorn/small_spot_io2_iops.postrun.json
@@ -53,6 +53,7 @@
         "status": "0",
         "filesystem": "/dev/nvme1n1",
         "instance_id": "i-01769a822e5dbb407",
+        "instance_type": "t3.small",
         "instance_availablity_zone": "us-east-1f",
         "total_input_size": "12K",
         "total_output_size": "36K",

--- a/tests/awsf3/postrunjson/GBPtlqb2rFGH.postrun.json
+++ b/tests/awsf3/postrunjson/GBPtlqb2rFGH.postrun.json
@@ -112,6 +112,7 @@
         "filesystem": "",
         "instance_availablity_zone": "",
         "instance_id": "",
+        "instance_type": "",
         "start_time": "20210312-14:04:23-UTC"
     },
     "config": {

--- a/tibanna/__main__.py
+++ b/tibanna/__main__.py
@@ -381,7 +381,11 @@ class Subcommands(object):
                   'help': "The ID of the Ubuntu 20.04 image to build from (e.g. 'ami-0885b1f6bd170450c' for us-east-1). " +
                           "To use this option, turn on the option -B."},
                  {'flag': ["-r", "--replicate"],
-                  'help': "Enable to replicate across all regions defined by AMI_PER_REGION"}
+                  'help': "Enable to replicate across all regions defined by AMI_PER_REGION"},
+                  {'flag': ["-a", "--architecture"],
+                  'help': "Architecture: x86 or Arm. Default: x86. " +
+                          "To use this option, turn on option -B. Ignored when option -U is used.",
+                  'default': "x86"}
                  ]
         }
 
@@ -525,10 +529,10 @@ def cleanup(usergroup, suffix='', purge_history=False, do_not_remove_iam_group=F
 
 
 def create_ami(make_public=False, build_from_scratch=False, source_image_to_copy_from=None, source_image_region=None,
-               ubuntu_base_image=None, replicate=False):
+               ubuntu_base_image=None, replicate=False, architecture="x86"):
     print(API().create_ami(make_public=make_public, build_from_scratch=build_from_scratch,
                            source_image_to_copy_from=source_image_to_copy_from, source_image_region=source_image_region,
-                           ubuntu_base_image=ubuntu_base_image, replicate=replicate))
+                           ubuntu_base_image=ubuntu_base_image, replicate=replicate, architecture=architecture))
 
 
 def main(Subcommands=Subcommands):

--- a/tibanna/awsem.py
+++ b/tibanna/awsem.py
@@ -291,7 +291,7 @@ class AwsemPostRunJsonJob(AwsemRunJsonJob):
                  start_time=None, end_time=None, status=None, Log=None,
                  total_input_size=None, total_output_size=None, total_tmp_size=None,
                  # older postrunjsons don't have these fields
-                 filesystem='', instance_id='', instance_availablity_zone='',
+                 filesystem='', instance_id='', instance_availablity_zone='', instance_type='',
                  Metrics=None, strict=True):
         if strict:
             if App is None or Input is None or Output is None or not JOBID or start_time is None:
@@ -303,6 +303,7 @@ class AwsemPostRunJsonJob(AwsemRunJsonJob):
         self.filesystem = filesystem
         self.instance_id = instance_id
         self.instance_availablity_zone = instance_availablity_zone
+        self.instance_type = instance_type
         self.total_input_size = total_input_size
         self.total_output_size = total_output_size
         self.total_tmp_size = total_tmp_size

--- a/tibanna/create_ami_userdata
+++ b/tibanna/create_ami_userdata
@@ -6,17 +6,20 @@ apt install -y awscli
 apt install -y apt-transport-https \
     ca-certificates \
     curl \
-    software-properties-common  # docker
+    gnupg \
+    lsb-release
 
 # install docker
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-apt-key fingerprint 0EBFCD88
-add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
-apt update # update again with an updated repository
-apt install -y docker-ce  # installing docker-ce
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+apt-get update
+apt-get --assume-yes install docker-ce
+
 usermod -aG docker ubuntu  # making it available for non-root user ubuntu
 
 reboot

--- a/tibanna/iam_utils.py
+++ b/tibanna/iam_utils.py
@@ -71,7 +71,7 @@ class IAM(object):
     @property
     def policy_types(self):
         return ['bucket', 'termination', 'list', 'cloudwatch', 'passrole', 'lambdainvoke',
-                'cloudwatch_metric', 'cw_dashboard', 'dynamodb', 'ec2_desc',
+                'cloudwatch_metric', 'cw_dashboard', 'dynamodb', 'ec2_desc', 'ec2_fleet',
                 'executions', 'pricing', 'vpc', 'kms']
 
     def policy_arn(self, policy_type):
@@ -94,6 +94,7 @@ class IAM(object):
                     'cw_dashboard': 'cw_dashboard',
                     'dynamodb': 'dynamodb',
                     'ec2_desc': 'ec2_desc',
+                    'ec2_fleet': 'ec2_fleet',
                     'pricing': 'pricing',
                     'executions': 'executions',
                     'vpc': 'vpc_access',
@@ -115,7 +116,8 @@ class IAM(object):
                        'cloudwatch_metric': self.policy_cloudwatch_metric,
                        'cw_dashboard': self.policy_cw_dashboard,
                        'dynamodb': self.policy_dynamodb,
-                       'ec2_desc': self.policy_ec2_desc_policy,
+                       'ec2_desc': self.policy_ec2_desc,
+                       'ec2_fleet': self.policy_ec2_fleet,
                        'pricing': self.policy_pricing,
                        'executions': self.policy_executions,
                        'vpc': self.policy_vpc_access,
@@ -156,7 +158,7 @@ class IAM(object):
         # returns a dictionary with role_type as keys
         # adding vpc access to only check_task since run_task has full ec2 access
         run_task_custom_policy_types = base + ['list', 'cloudwatch', 'passrole', 'dynamodb',
-                                               'executions', 'cw_dashboard']
+                                               'executions', 'cw_dashboard', 'ec2_fleet']
         check_task_custom_policy_types = base + ['cloudwatch_metric', 'cloudwatch', 'ec2_desc',
                                                  'termination', 'dynamodb', 'pricing', 'vpc']
         update_cost_custom_policy_types = base + ['executions', 'dynamodb', 'pricing', 'vpc']
@@ -392,6 +394,24 @@ class IAM(object):
         return policy
 
     @property
+    def policy_ec2_fleet(self):
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:ListRoles",
+                        "iam:PassRole",
+                        "iam:ListInstanceProfiles"
+                    ],
+                    "Resource":"*"
+                }
+            ]
+        }
+        return policy
+
+    @property
     def policy_cw_dashboard(self):
         policy = {
             "Version": "2012-10-17",
@@ -427,7 +447,7 @@ class IAM(object):
         return policy
 
     @property
-    def policy_ec2_desc_policy(self):
+    def policy_ec2_desc(self):
         policy = {
             "Version": "2012-10-17",
             "Statement": [

--- a/tibanna/job.py
+++ b/tibanna/job.py
@@ -309,7 +309,8 @@ class Job(object):
                         'Time Stamp': {
                             'S': time_stamp
                         }
-                    }
+                    },
+                    ReturnConsumedCapacity='TOTAL'
                 )
                 if 'CapacityUnits' in response['ConsumedCapacity']:
                     if verbose:

--- a/tibanna/pricing_utils.py
+++ b/tibanna/pricing_utils.py
@@ -87,10 +87,12 @@ def get_cost_estimate(postrunjson, ebs_root_type = "gp3", aws_price_overwrite = 
 
             if(not job.instance_availablity_zone):
                 raise PricingRetrievalException("Instance availability zone is not available. You might have to deploy a newer version of Tibanna.")
+            if(not job.instance_type):
+                raise PricingRetrievalException("Instance type is not available. You might have to deploy a newer version of Tibanna.")
 
             ec2_client=boto3.client('ec2',region_name=AWS_REGION)
             prices=ec2_client.describe_spot_price_history(
-                InstanceTypes=[cfg.instance_type],
+                InstanceTypes=[job.instance_type],
                 ProductDescriptions=['Linux/UNIX'],
                 AvailabilityZone=job.instance_availablity_zone,
                 MaxResults=1) # Most recent price is on top
@@ -111,7 +113,7 @@ def get_cost_estimate(postrunjson, ebs_root_type = "gp3", aws_price_overwrite = 
                 {
                     'Type': 'TERM_MATCH',
                     'Field': 'instanceType',
-                    'Value': cfg.instance_type
+                    'Value': job.instance_type
                 },
                 {
                     'Type': 'TERM_MATCH',

--- a/tibanna/pricing_utils.py
+++ b/tibanna/pricing_utils.py
@@ -77,6 +77,10 @@ def get_cost_estimate(postrunjson, ebs_root_type = "gp3", aws_price_overwrite = 
     job_end = datetime.strptime(job.end_time, '%Y%m%d-%H:%M:%S-UTC')
     job_duration = (job_end - job_start).seconds / 3600.0 # in hours
 
+    if(not job.instance_type):
+        logger.warning("Instance type is not available for cost estimation. Please try to deploy the latest version of Tibanna.")
+        return 0.0, "NA"
+
     try:
         pricing_client = boto3.client('pricing', region_name=AWS_REGION)
 
@@ -87,9 +91,7 @@ def get_cost_estimate(postrunjson, ebs_root_type = "gp3", aws_price_overwrite = 
 
             if(not job.instance_availablity_zone):
                 raise PricingRetrievalException("Instance availability zone is not available. You might have to deploy a newer version of Tibanna.")
-            if(not job.instance_type):
-                raise PricingRetrievalException("Instance type is not available. You might have to deploy a newer version of Tibanna.")
-
+            
             ec2_client=boto3.client('ec2',region_name=AWS_REGION)
             prices=ec2_client.describe_spot_price_history(
                 InstanceTypes=[job.instance_type],

--- a/tibanna/vars.py
+++ b/tibanna/vars.py
@@ -38,30 +38,35 @@ if not AWS_REGION:
 # Tibanna AMI info
 # Override this mapping to use a custom AMI scheme
 AMI_PER_REGION = {
-    'us-east-1': 'ami-06e2266f85063aabc',  # latest as of Oct 25 2021
-    'us-east-2': 'ami-03a4e3e84b6a1813d',
-    'us-west-1': 'ami-0c5e8147be760a354',
-    'us-west-2': 'ami-068589fed9c8d5950',
-    'ap-south-1': 'ami-05ef59bc4f359c93b',
-    'ap-northeast-2': 'ami-0d8618a76aece8a8e',
-    'ap-southeast-1': 'ami-0c22dc3b05714bda1',
-    'ap-southeast-2': 'ami-03dc109bbf412aac5',
-    'ap-northeast-1': 'ami-0f4c520515c41ff46',
-    'ca-central-1': 'ami-01af127710fadfe74',
-    'eu-central-1': 'ami-0887bcb1c901c1769',
-    'eu-west-1': 'ami-08db59692e4371ea6',
-    'eu-west-2': 'ami-036d3ce7a21e07012',
-    'eu-west-3': 'ami-0cad0ec4160a6b940',
-    'eu-north-1': 'ami-00a6f0f9fee951aa0',
-    'sa-east-1': 'ami-0b2164f9680f97099',
-    'me-south-1': 'ami-03479b7a590f97945',
-    'af-south-1': 'ami-080baa4ec59c456aa',
-    'ap-east-1': 'ami-0a9056eb817bc3928',
-    'eu-south-1': 'ami-0a72279e56849415e'
+    'x86': {
+        'us-east-1': 'ami-06e2266f85063aabc',  # latest as of Oct 25 2021
+        'us-east-2': 'ami-03a4e3e84b6a1813d',
+        'us-west-1': 'ami-0c5e8147be760a354',
+        'us-west-2': 'ami-068589fed9c8d5950',
+        'ap-south-1': 'ami-05ef59bc4f359c93b',
+        'ap-northeast-2': 'ami-0d8618a76aece8a8e',
+        'ap-southeast-1': 'ami-0c22dc3b05714bda1',
+        'ap-southeast-2': 'ami-03dc109bbf412aac5',
+        'ap-northeast-1': 'ami-0f4c520515c41ff46',
+        'ca-central-1': 'ami-01af127710fadfe74',
+        'eu-central-1': 'ami-0887bcb1c901c1769',
+        'eu-west-1': 'ami-08db59692e4371ea6',
+        'eu-west-2': 'ami-036d3ce7a21e07012',
+        'eu-west-3': 'ami-0cad0ec4160a6b940',
+        'eu-north-1': 'ami-00a6f0f9fee951aa0',
+        'sa-east-1': 'ami-0b2164f9680f97099',
+        'me-south-1': 'ami-03479b7a590f97945',
+        'af-south-1': 'ami-080baa4ec59c456aa',
+        'ap-east-1': 'ami-0a9056eb817bc3928',
+        'eu-south-1': 'ami-0a72279e56849415e'
+    },
+    'Arm': {
+        'us-east-1': 'ami-0e12894d2dc91ab8c',
+    }
 }
-if AWS_REGION not in AMI_PER_REGION:
-    logger.warning("Public Tibanna AMI for region %s is not available." % AWS_REGION)
-AMI_ID = AMI_PER_REGION.get(AWS_REGION, '')
+# if AWS_REGION not in AMI_PER_REGION:
+#     logger.warning("Public Tibanna AMI for region %s is not available." % AWS_REGION)
+# AMI_ID = AMI_PER_REGION.get(AWS_REGION, '')
 
 AWS_REGION_NAMES = {
     'us-east-1': 'US East (N. Virginia)',

--- a/tibanna/vars.py
+++ b/tibanna/vars.py
@@ -64,9 +64,6 @@ AMI_PER_REGION = {
         'us-east-1': 'ami-0e12894d2dc91ab8c',
     }
 }
-# if AWS_REGION not in AMI_PER_REGION:
-#     logger.warning("Public Tibanna AMI for region %s is not available." % AWS_REGION)
-# AMI_ID = AMI_PER_REGION.get(AWS_REGION, '')
 
 AWS_REGION_NAMES = {
     'us-east-1': 'US East (N. Virginia)',


### PR DESCRIPTION
This PR adds support for Arm-based instances. Furthermore, instead of using the `run_instance` command we switch to EC2 fleets (in instant mode) to start up instances. This way, AWS will pick the most suitable option when a list of instance types is supplied.