### PR TITLE
Add `arm_per_region` as option, fix Singularity, reduce build time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,22 @@
 Change Log
 ==========
 
+3.1.0
+=====
+
+* Add config option ``ami_per_region``.
+* Bump ``cwltool`` version to ``3.1.20211103193132``.
+* Singularity was not working. Also, bump Singularity version to ``3.10.4``.
+* Speed up Tibanna docker build.
+* Fix Goofys installation on ARM architecture.
+
+
+3.0.1
+=====
+
+* Add CodeBuild specification.
+
+
 3.0.0
 =====
 

--- a/awsf3-docker/Dockerfile
+++ b/awsf3-docker/Dockerfile
@@ -12,8 +12,6 @@ RUN apt update -y && apt upgrade -y &&  apt install -y \
     cron \
     curl \
     fuse \
-    gcc \
-    g++ \
     git \
     less \
     locales \
@@ -25,7 +23,6 @@ RUN apt update -y && apt upgrade -y &&  apt install -y \
     vim \
     wget \
     software-properties-common \
-    build-essential \
     libssl-dev \
     libwww-perl \
     libdatetime-perl \
@@ -55,33 +52,22 @@ RUN echo \
 RUN apt-get update
 RUN apt-get --assume-yes install docker-ce
 
-# singularity
+# Singularity
 RUN ARCH="$(dpkg --print-architecture)" && \
-    wget "https://golang.org/dl/go1.16.6.linux-${ARCH}.tar.gz" && \
-    tar -xzf "go1.16.6.linux-${ARCH}.tar.gz" && \
-    rm "go1.16.6.linux-${ARCH}.tar.gz"
-RUN export SINGULARITY_VERSION=3.8.1 && \
-    export PATH=/usr/local/bin/go/bin/:$PATH && \
-    wget https://github.com/sylabs/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-ce-${SINGULARITY_VERSION}.tar.gz && \
-    tar -xzf singularity-ce-${SINGULARITY_VERSION}.tar.gz && \
-    rm singularity-ce-${SINGULARITY_VERSION}.tar.gz && \
-    cd singularity-ce-${SINGULARITY_VERSION} && \
-    ./mconfig && \
-    make -C ./builddir && \
-    make -C ./builddir install && \
-    cd .. && \
-    rm -rf go && \
-    rm -rf singularity-ce-${SINGULARITY_VERSION}
+    SINGULARITY_VERSION=3.10.4 && \
+    wget https://tibanna-dependencies.s3.amazonaws.com/singularity/singularity-ce_${SINGULARITY_VERSION}-focal_${ARCH}.deb && \
+    apt install -y ./singularity-ce_${SINGULARITY_VERSION}-focal_${ARCH}.deb && \
+    rm singularity-ce_${SINGULARITY_VERSION}-focal_${ARCH}.deb
 
 # goofys
-# RUN curl -O -L http://bit.ly/goofys-latest && chmod +x goofys-latest  # latest is not latest
-RUN wget https://github.com/kahing/goofys/releases/download/v0.24.0/goofys && chmod +x goofys
+# RUN wget https://github.com/kahing/goofys/releases/download/v0.24.0/goofys && chmod +x goofys
+RUN ARCH="$(dpkg --print-architecture)" && \
+    wget https://tibanna-dependencies.s3.amazonaws.com/goofys/v0.24.0/${ARCH}/goofys && chmod +x goofys
 
 # python packages
 RUN pip install boto3==1.15 awscli==1.18.152 botocore==1.18.11
 RUN pip install psutil==5.7.3
-#RUN pip install schema-salad==2.7.20180514132321 cwltool==1.0.20180525185854  # old set up, doesn't work for python3
-RUN pip install schema-salad==7.0.20200811075006 cwltool==3.0.20201017180608
+RUN pip install cwltool==3.1.20211103193132
 RUN pip install ec2metadata==2.0.1
 
 # cromwell for WDL 1.0

--- a/awsf3-docker/run.sh
+++ b/awsf3-docker/run.sh
@@ -298,11 +298,20 @@ else
     exl echo "Error: CWL draft3 is no longer supported. Please switch to v1"
     handle_error 1
   fi
-  # cwltool cannot recognize symlinks and end up copying output from tmp directory intead of moving.
-  # To prevent this, use the original directory name here.
-  exl echo "cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --custom-net host --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE"
+
   mkdir -p $LOCAL_WF_TMPDIR_CWL
-  exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --custom-net host --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
+  if [[ $SINGULARITY_OPTION == '--singularity' ]]
+  then
+    exl echo "Using Singularity"
+    # Singularity can't be run with --custom-net host
+    exl echo "cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE"
+    exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
+  else
+    # cwltool cannot recognize symlinks and end up copying output from tmp directory intead of moving.
+    # To prevent this, use the original directory name here.
+    exl echo "cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --custom-net host --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE"
+    exlj cwltool --enable-dev --non-strict --no-read-only --no-match-user $RUN_ARGS --custom-net host --outdir $LOCAL_OUTDIR_CWL --tmp-outdir-prefix $LOCAL_WF_TMPDIR_CWL --tmpdir-prefix $LOCAL_WF_TMPDIR_CWL $PRESERVED_ENV_OPTION $SINGULARITY_OPTION $MAIN_CWL $cwd0/$INPUT_YML_FILE
+  fi
   handle_error $?
 fi
 cd $cwd0

--- a/docs/ami.rst
+++ b/docs/ami.rst
@@ -6,3 +6,27 @@ Tibanna now uses the Amazon Machine Images (AMI) ``ami-06e2266f85063aabc`` (``x8
 
 For regions that are not ``us-east-1``, copies of these AMIs are publicly available (different AMI IDs) and are auto-detected by Tibanna.
 
+If you want to use your own AMI, you can overwrite the default values in the ``config`` field of the Job Description JSON:
+::
+
+    {
+      "args": {
+        ...
+      },
+      "config": {
+        ...
+        "ami_per_region": {
+          "x86": {
+            "us-east-1": "my_x86_ami_ue1",
+            "us-east-2": "my_x86_ami_ue2",
+            ...
+          },
+          "Arm": {
+            "us-east-1": "my_arm_ami_ue1",
+            "us-east-2": "my_arm_ami_ue2",
+            ...
+          }
+        },
+      }
+    }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "3.0.0"
+version = "3.1.0"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/scripts/publish-docker
+++ b/scripts/publish-docker
@@ -7,3 +7,8 @@ export AWSF_IMAGE=$(python -c 'from tibanna.vars import DEFAULT_AWSF_IMAGE; prin
 # Your local docker driver needs to support the multiple platforms feature
 docker buildx build --push --platform linux/amd64,linux/arm64 -t $AWSF_IMAGE --build-arg version=$VERSION awsf3-docker/ > $BUILD_LOG
 
+# To push to ECR use (after log in), run
+#export AWSF_IMAGE="xxx.dkr.ecr.us-east-1.amazonaws.com/tibanna-awsf:$VERSION"
+#echo $AWSF_IMAGE
+#docker buildx build --push --platform linux/amd64,linux/arm64 -t $AWSF_IMAGE --build-arg version=$VERSION awsf3-docker/ > $BUILD_LOG
+

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -326,6 +326,8 @@ class Config(SerializableObject):
             self.ebs_size_as_is = False
         if not hasattr(self, 'ami_id'):
             self.ami_id = "" # will be assigned instance architecture specific later
+        if not hasattr(self, 'ami_per_region'):
+            self.ami_per_region = AMI_PER_REGION
             
         # special handling for subnet, SG if not set already pull from env
         # values from config take priority - omit them to get these values from lambda
@@ -431,10 +433,11 @@ class Execution(object):
                 'EBS_optimized': is_ebs_optimized
             }
             arch = result['ProcessorInfo']['SupportedArchitectures'][0]
-            default_ami = AMI_PER_REGION['Arm'].get(AWS_REGION, '') if arch == 'arm64' else AMI_PER_REGION['x86'].get(AWS_REGION, '')
+            default_ami = self.cfg.ami_per_region['Arm'].get(AWS_REGION, '') if arch == 'arm64' else self.cfg.ami_per_region['x86'].get(AWS_REGION, '')
             if self.cfg.ami_id:
                 # if a user supplied an ami_id, it will be used for every instance. 
                 # will be problematic if the instance list contains x86 and Arm instances
+                # Instead, users should provide ami_per_region
                 ami_ebs_info[instance_type]['ami_id'] = self.cfg.ami_id
             elif default_ami:
                 ami_ebs_info[instance_type]['ami_id'] = default_ami


### PR DESCRIPTION
- `arm_per_region` is now configurable as config option. This is required to make it compatible to `tibanna_ff`, where we need to overwrite the used AMIs
- Singularity was not working at all. This has been fixed together with a `cwltool` version bump. Also, it is now working on ARM instances. An ARM/AMD Singularity `.deb`  package has been compiled for simpler installation in the Tibanna docker image. These packages are pulled from S3.
- The docker build time has been reduced as all installations from source have been removed
- Mounting via Goofys has been fixed for ARM instances