### PR TITLE
Accept kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "3.2.1"
+version = "3.2.2"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna/ami.py
+++ b/tibanna/ami.py
@@ -20,7 +20,7 @@ class AMI(object):
     AMI_NAME = 'tibanna-ami-' + datetime.strftime(datetime.today(), '%Y%m%d')  # e.g tibanna-ami-20201113
     ARCHITECTURE = 'x86'
 
-    def __init__(self, base_ami=None, base_region=None, userdata_file=None, ami_name=None, architecture=None):
+    def __init__(self, base_ami=None, base_region=None, userdata_file=None, ami_name=None, architecture=None, **kwargs):
         if base_ami:
             self.BASE_AMI = base_ami
         elif architecture == 'x86':

--- a/tibanna/awsem.py
+++ b/tibanna/awsem.py
@@ -9,7 +9,7 @@ from .nnested_array import flatten
 
 
 class AwsemRunJson(SerializableObject):
-    def __init__(self, Job=None, config=None, strict=True):
+    def __init__(self, Job=None, config=None, strict=True, **kwargs):
         if strict:
             if not Job or not config:
                 raise MalFormattedPostRunJsonException("Job and config are required fields.")
@@ -24,7 +24,7 @@ class AwsemRunJson(SerializableObject):
 
 class AwsemRunJsonJob(SerializableObject):
     def __init__(self, App=None, Input=None, Output=None, JOBID='',
-                 start_time=None, Log=None, strict=True):
+                 start_time=None, Log=None, strict=True, **kwargs):
         if strict:
             if App is None or Input is None or Output is None or not JOBID:
                 raise MalFormattedRunJsonException
@@ -63,7 +63,7 @@ class AwsemRunJsonJob(SerializableObject):
 
 
 class AwsemRunJsonLog(SerializableObject):
-    def __init__(self, log_bucket_directory=None):
+    def __init__(self, log_bucket_directory=None, **kwargs):
         self.log_bucket_directory = log_bucket_directory
 
 
@@ -72,7 +72,8 @@ class AwsemRunJsonApp(SerializableObject):
                  cwl_url=None, main_cwl=None, other_cwl_files=None,
                  wdl_url=None, main_wdl=None, other_wdl_files=None, workflow_engine=None, run_args=None,
                  container_image=None, command=None,
-                 snakemake_url=None, main_snakemake=None, other_snakemake_files=None):
+                 snakemake_url=None, main_snakemake=None, other_snakemake_files=None,
+                 **kwargs):
         self.App_name = App_name
         self.App_version = App_version
         self.language = language
@@ -90,11 +91,12 @@ class AwsemRunJsonApp(SerializableObject):
         self.main_snakemake = main_snakemake
         self.other_snakemake_files = other_snakemake_files
 
+
 class AwsemRunJsonInput(SerializableObject):
     def __init__(self, Input_files_data=None, Input_parameters=None, Secondary_files_data=None,
                  # Input_files_reference is for older postrunjson
                  # Env is missing in older postrunjson
-                 Input_files_reference=None, Env=None):
+                 Input_files_reference=None, Env=None, **kwargs):
         if not Input_files_data:
             Input_files_data = {}
         if not Input_parameters:
@@ -223,7 +225,7 @@ class AwsemRunJsonInputFile(SerializableObject):
 
 class AwsemRunJsonOutput(SerializableObject):
     def __init__(self, output_bucket_directory=None, output_target=None,
-                 secondary_output_target=None, alt_cond_output_argnames=None):
+                 secondary_output_target=None, alt_cond_output_argnames=None, **kwargs):
         self.output_bucket_directory = output_bucket_directory or {}
         self.output_target = output_target or {}
         self.secondary_output_target = secondary_output_target or {}
@@ -269,7 +271,7 @@ class AwsemRunJsonOutput(SerializableObject):
 
 
 class AwsemPostRunJson(AwsemRunJson):
-    def __init__(self, Job=None, config=None, commands=None,log=None, strict=True):
+    def __init__(self, Job=None, config=None, commands=None, log=None, strict=True, **kwargs):
         if strict:
             if not Job or not config:
                 raise MalFormattedPostRunJsonException("Job and config are required fields.")
@@ -292,7 +294,7 @@ class AwsemPostRunJsonJob(AwsemRunJsonJob):
                  total_input_size=None, total_output_size=None, total_tmp_size=None,
                  # older postrunjsons don't have these fields
                  filesystem='', instance_id='', instance_availablity_zone='', instance_type='',
-                 Metrics=None, strict=True):
+                 Metrics=None, strict=True, **kwargs):
         if strict:
             if App is None or Input is None or Output is None or not JOBID or start_time is None:
                 errmsg = "App, Input, Output, JOBID and start_time are required fields"

--- a/tibanna/job.py
+++ b/tibanna/job.py
@@ -35,7 +35,7 @@ class Jobs(object):
 
 class Job(object):
 
-    def __init__(self, job_id=None, exec_arn=None, sfn=None):
+    def __init__(self, job_id=None, exec_arn=None, sfn=None, **kwargs):
         """A job can be identified with either a job_id or an exec_arn.
         For old tibanna versions (with no dynamoDB deployed),
         a job can be identified with a job_id and sfn.


### PR DESCRIPTION
Here, we add `**kwargs` to various class constructor methods, specifically those that are used elsewhere in the form `Class(**properties)`. 

This design pattern (creating classes by dumping unspecified properties) is not ideal IMO, and it had caused the cost updates to MWFRs to silently fail for a long time. Rather than refactoring this design pattern, we add `kwargs` to prevent similar issues from cropping up in the future.