### PR TITLE
Add `instance_start_time` to `tibanna stat`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,27 @@
 Change Log
 ==========
 
+
+3.3.2
+=====
+
+* Add ``instance_start_time`` to ``tibanna stat`` command
+
+
+3.3.1
+=====
+`PR 390: Bump Benchmark <https://github.com/4dn-dcic/tibanna/pull/390>`_
+
+* Bump Benchmark
+
+
+3.3.0
+=====
+`PR 388: Improved fleet error handling + smaller fixes <https://github.com/4dn-dcic/tibanna/pull/388>`_
+
+* Improved fleet error handling + smaller fixes
+
+
 3.2.2
 =====
 `PR 387: Add kwargs <https://github.com/4dn-dcic/tibanna/pull/387>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "3.3.1"
+version = "3.3.2"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
This PR extends the `tibanna stat` command and returns now also the `instance_start_time` in addition to the `execution_start_time`. This is helpful if we want to assess the time that it took to obtain the EC2 instance from AWS.

Old result:
```
tibanna stat --job-ids=jc5RYG75yURz -l
jobid	status	name	start_time	stop_time	instance_id	instance_type	instance_status	ip	key
jc5RYG75yURz	SUCCEEDED	run_bam_to_fastq_paired-end	2023-07-19 17:15	2023-07-19 20:02	-   -	-	-	-
```
New result:
```
tibanna stat --job-ids=jc5RYG75yURz -l
jobid	status	name	execution_start_time	execution_stop_time	instance_id	instance_start_time	instance_type	instance_status	ip	key
jc5RYG75yURz	SUCCEEDED	run_bam_to_fastq_paired-end	2023-07-19 17:15	2023-07-19 20:02	-	2023-07-19 17:16	-	-	-	-
```

I am using the creation time of the file `<job_id>.job_started` as proxy for the start time of the EC2.