### PR TITLE
Update ec2_utils.py to handle SpotInstance limits

### DIFF
--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -573,7 +573,7 @@ class Execution(object):
                     self.delete_launch_template()
                     raise Exception(f"Invalid fleet configuration. Result from create_fleet command: {json.dumps(fleet_result)}")
                 
-                elif 'InsufficientInstanceCapacity' in error_codes or 'InstanceLimitExceeded' in error_codes or 'UnfulfillableCapacity' in error_codes:
+                elif 'InsufficientInstanceCapacity' in error_codes or 'InstanceLimitExceeded' in error_codes or 'UnfulfillableCapacity' in error_codes or 'MaxSpotInstanceCountExceeded'in error_codes:
                     # We ignore the 'InvalidFleetConfiguration' error here
                     behavior = self.cfg.behavior_on_capacity_limit
                     if behavior == 'fail':


### PR DESCRIPTION
When having too many spot instance requests (depending on the account quota), the error code `MaxSpotInstanceCountExceeded` is returned. 

Currently the job just fails, but it would be nice if tibanna retries until the spot instances can be requested again. 

In such a case it then depends on `behavior` what will happen.