### PR TITLE
Fix docker version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Change Log
 ==========
 
+5.2.2
+=====
+
+* Fix docker version in awsf3 Dockerfile
+
+
 5.2.1
 =====
 

--- a/awsf3-docker/Dockerfile
+++ b/awsf3-docker/Dockerfile
@@ -1,6 +1,4 @@
 FROM ubuntu:20.04
-MAINTAINER Soo Lee (duplexa@gmail.com)
-
 
 # general updates & installing necessary Linux components
 ENV DEBIAN_FRONTEND=noninteractive
@@ -50,7 +48,7 @@ RUN echo \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 RUN apt-get update
-RUN apt-get --assume-yes install docker-ce
+RUN apt-get --assume-yes install docker-ce=5:24.0.7-1~ubuntu.20.04~focal
 
 # Singularity
 RUN ARCH="$(dpkg --print-architecture)" && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "5.2.1"
+version = "5.2.2"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"


### PR DESCRIPTION
Fixes the docker version that we are installing within the awfs docker image. Newer versions will build, but workflows will fail with the following error:
```
## Starting docker in the AWSF container
/etc/init.d/docker: 62: ulimit: error setting limit (Invalid argument)
```