### PR TITLE
Fix parser for top command output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Change Log
 ==========
 
+5.4.3
+=====
+
+* Fix bug when parsing output from top command
+
+
 5.4.2
 =====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tibanna"
-version = "5.4.2"
+version = "5.4.3"
 description = "Tibanna runs portable pipelines (in CWL/WDL) on the AWS Cloud."
 authors = ["4DN-DCIC Team <support@4dnucleome.org>"]
 license = "MIT"

--- a/tibanna/top.py
+++ b/tibanna/top.py
@@ -93,7 +93,9 @@ class Top(object):
         is_in_table = False
         for line in contents.splitlines():
             if line.startswith('Timestamp:'):
-                timestamp = line.split()[1]
+                line_split = line.split()
+                if len(line_split) > 1:
+                    timestamp = line_split[1]
                 continue
             if line.lstrip().startswith('PID'):
                 is_in_table = True


### PR DESCRIPTION
The output of the top command can contain the following.

<img width="656" alt="image" src="https://github.com/user-attachments/assets/15d712dd-9616-4017-aef5-b7cc4820827f">


This PR makes sure that the timestamp is retrieved correctly in this case