### PR TITLE
Security - refactor Tibanna to use IMDSv2 and IMDSv2 calls for metada…

### DIFF
--- a/awsf/aws_run_workflow_generic.sh
+++ b/awsf/aws_run_workflow_generic.sh
@@ -65,9 +65,10 @@ export LOGFILE2=$LOCAL_OUTDIR/$JOBID.log
 export LOGJSONFILE=$LOCAL_OUTDIR/$JOBID.log.json
 export STATUS=0
 export ERRFILE=$LOCAL_OUTDIR/$JOBID.error  # if this is found on s3, that means something went wrong.
-export INSTANCE_ID=$(ec2metadata --instance-id|cut -d' ' -f2)
-export INSTANCE_REGION=$(ec2metadata --availability-zone | sed 's/[a-z]$//')
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity| grep Account | sed 's/[^0-9]//g')
+# IMDSv2-safe instance metadata using Python
+export INSTANCE_ID=$(python3 -c "from ec2_metadata import ec2_metadata; print(ec2_metadata.instance_id)")
+export INSTANCE_REGION=$(python3 -c "from ec2_metadata import ec2_metadata; print(ec2_metadata.availability_zone[:-1])")
 
 if [[ $LANGUAGE == 'wdl' ]]
 then

--- a/awsf3-docker/Dockerfile
+++ b/awsf3-docker/Dockerfile
@@ -66,7 +66,7 @@ RUN ARCH="$(dpkg --print-architecture)" && \
 RUN pip install boto3==1.15 awscli==1.18.152 botocore==1.18.11
 RUN pip install psutil==5.7.3
 RUN pip install cwltool==3.1.20211103193132
-RUN pip install ec2metadata==2.0.1
+RUN pip install ec2-metadata
 
 # cromwell for WDL 1.0
 RUN wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar && \

--- a/awsf3-docker/run.sh
+++ b/awsf3-docker/run.sh
@@ -45,10 +45,15 @@ export LOGJSONFILE=$LOCAL_OUTDIR/$JOBID.log.json
 export ERRFILE=$LOCAL_OUTDIR/$JOBID.error  # if this is found on s3, that means something went wrong.
 export TOPFILE=$LOCAL_OUTDIR/$JOBID.top  # now top command output goes to a separate file
 export TOPLATESTFILE=$LOCAL_OUTDIR/$JOBID.top_latest  # this one includes only the latest top command output
-export INSTANCE_ID=$(ec2metadata --instance-id|cut -d' ' -f2)
-export INSTANCE_REGION=$(ec2metadata --availability-zone | sed 's/[a-z]$//')
-export INSTANCE_AVAILABILITY_ZONE=$(ec2metadata --availability-zone)
-export INSTANCE_TYPE=$(ec2metadata --instance-type)
+# IMDSv2-safe metadata
+export INSTANCE_ID=$(python3 -c "from ec2_metadata import ec2_metadata; print(ec2_metadata.instance_id)")
+export INSTANCE_AVAILABILITY_ZONE=$(python3 -c "from ec2_metadata import ec2_metadata; print(ec2_metadata.availability_zone)")
+export INSTANCE_REGION=$(python3 -c "from ec2_metadata import ec2_metadata; print(ec2_metadata.availability_zone[:-1])")
+export INSTANCE_TYPE=$(python3 -c "from ec2_metadata import ec2_metadata; print(ec2_metadata.instance_type)")
+echo "INSTANCE_ID: $INSTANCE_ID"
+echo "AZ: $INSTANCE_AVAILABILITY_ZONE"
+echo "Region: $INSTANCE_REGION"
+echo "Instance Type: $INSTANCE_TYPE"
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity| grep Account | sed 's/[^0-9]//g')
 export AWS_REGION=$INSTANCE_REGION  # this is for importing awsf3 package which imports tibanna package
 export LOCAL_OUTDIR_CWL=$MOUNT_DIR_PREFIX$LOCAL_OUTDIR

--- a/old/AMI/create_tibanna_ami.py
+++ b/old/AMI/create_tibanna_ami.py
@@ -15,6 +15,11 @@ def launch_instance_for_tibanna_ami(keyname, userdata_file='AMI/tibanna_ami.sh')
                    'UserData': userdata_str,
                    'MaxCount': 1,
                    'MinCount': 1,
+                   'MetadataOptions': {
+                       'HttpTokens': 'required',
+                       'HttpEndpoint': 'enabled',
+                       'HttpPutResponseHopLimit': 2
+                    },
                    'TagSpecifications': [{'ResourceType': 'instance',
                                           'Tags': [{"Key": "Name", "Value": "tibanna_ami"}]}]}
     if keyname:

--- a/tibanna/ami.py
+++ b/tibanna/ami.py
@@ -50,6 +50,11 @@ class AMI(object):
                        'InstanceType': instanceType,
                        'MaxCount': 1,
                        'MinCount': 1,
+                       'MetadataOptions': {
+                           'HttpTokens': 'required',
+                           'HttpEndpoint': 'enabled',
+                           'HttpPutResponseHopLimit': 2
+                       },
                        'TagSpecifications': [{'ResourceType': 'instance',
                                               'Tags': [{"Key": "Name", "Value": "tibanna_ami"}]}]}
         if userdata_file:

--- a/tibanna/ec2_utils.py
+++ b/tibanna/ec2_utils.py
@@ -808,6 +808,11 @@ class Execution(object):
                         }
                 }
             ],
+            'MetadataOptions': {
+                'HttpTokens': 'required',
+                'HttpEndpoint': 'enabled',
+                'HttpPutResponseHopLimit': 2
+            },
             'TagSpecifications': [
                 {
                     'ResourceType': 'instance',


### PR DESCRIPTION
I was able to refactor Tibanna so it works with IMDSv2. I tested the changes in a test AWS account using a local build of the Tibanna repo and it successfully launched IMDSv2 instances and ran the hello world pipeline.
The prebuilt DockerHub image doesn’t include these changes which is why my local ECR build worked but the public image didn’t.
Discussed with Will to review/merge my changes and once my PR is merged you'd just need to rebuild + push a new Tibanna Docker image so Tibanna jobs can use the IMDSv2-compatible version and be compliant with our HMS DBMI Cloud Security Standards.