### PR TITLE
migrate all workflows to OIDC auth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,10 +77,9 @@ jobs:
           make install
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
       
       - name: QA (unit)
@@ -110,10 +109,9 @@ jobs:
           make install
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
       
       - name: QA (unit)
@@ -143,10 +141,9 @@ jobs:
           make install
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
       
       - name: QA (unit)
@@ -176,10 +173,9 @@ jobs:
           make install
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
       
       - name: QA (unit)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
+permissions: #Needed for OIDC authentication
+  id-token: write
+  contents: read    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # In this case, since this repo (tibanna) has tests which cannot reliablly run concurrently,
 # because (at least) they write/read to/from fixed locations in S3, we need to run the tests
@@ -43,10 +45,9 @@ jobs:
           make install
           
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
       
       - name: QA (unit)


### PR DESCRIPTION
Summary
Replaces static AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets
with OIDC role assumption across all workflows. This is more secure
as it eliminates long-lived AWS credentials stored as GitHub secrets.

Changes
main.yml — switched to OIDC auth, bumped configure-aws-credentials v1 → v4 (required for OIDC), added permissions: id-token: write block (required for GitHub to issue OIDC token)
Testing
✅ CI passed on this branch
✅ AWS credentials step passes with OIDC role assumption confirmed
After this is merged
The following repo secrets can be deleted by an admin if not used in other areas of the pipeline:

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_OIDC_ROLE_ARN must remain.
