### PR TITLE
Fix workflow filenames containing spaces

### DIFF
--- a/awsf3/utils.py
+++ b/awsf3/utils.py
@@ -30,7 +30,11 @@ WORKFLOW_FILES_JSON_PREFIX = 'json:'
 
 def encode_workflow_files(workflow_files):
     """Serialize comma-separated workflow filenames for an environment variable."""
-    workflow_files = workflow_files.split(',') if workflow_files else []
+    workflow_files = [
+        filename.strip()
+        for filename in workflow_files.split(',')
+        if filename.strip()
+    ] if workflow_files else []
     return WORKFLOW_FILES_JSON_PREFIX + json.dumps(workflow_files)
 
 
@@ -43,7 +47,7 @@ def decode_workflow_files(workflow_files):
         if not isinstance(workflow_files, list) or not all(isinstance(filename, str) for filename in workflow_files):
             raise ValueError("Workflow files must be a list of filenames")
         return workflow_files
-    return workflow_files.split(' ') if ' ' in workflow_files else [workflow_files]
+    return workflow_files.split()
 
 
 def decode_run_json(input_json_file, kms_key_id=None, region=None):

--- a/awsf3/utils.py
+++ b/awsf3/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 import subprocess
 import boto3
 import re
@@ -24,6 +25,25 @@ input_yml_filename = "inputs.yml"
 env_filename = "env_command_list.txt"
 INPUT_DIR = "/data1/input"  # data are downloaded to this directory
 INPUT_MOUNT_DIR_PREFIX = "/data1/input-mounted-"  # data are mounted to this directory + bucket name
+WORKFLOW_FILES_JSON_PREFIX = 'json:'
+
+
+def encode_workflow_files(workflow_files):
+    """Serialize comma-separated workflow filenames for an environment variable."""
+    workflow_files = workflow_files.split(',') if workflow_files else []
+    return WORKFLOW_FILES_JSON_PREFIX + json.dumps(workflow_files)
+
+
+def decode_workflow_files(workflow_files):
+    """Deserialize workflow filenames, retaining support for the legacy format."""
+    if not workflow_files:
+        return []
+    if workflow_files.startswith(WORKFLOW_FILES_JSON_PREFIX):
+        workflow_files = json.loads(workflow_files[len(WORKFLOW_FILES_JSON_PREFIX):])
+        if not isinstance(workflow_files, list) or not all(isinstance(filename, str) for filename in workflow_files):
+            raise ValueError("Workflow files must be a list of filenames")
+        return workflow_files
+    return workflow_files.split(' ') if ' ' in workflow_files else [workflow_files]
 
 
 def decode_run_json(input_json_file, kms_key_id=None, region=None):
@@ -200,14 +220,15 @@ def create_env_def_file(env_filename, runjson, language):
         f_env.write("export LANGUAGE={}\n".format(app.language))
         if language in ['wdl', 'wdl_v1', 'wdl_draft2']:
             f_env.write("export WDL_URL={}\n".format(app.wdl_url))
-            f_env.write("export MAIN_WDL={}\n".format(app.main_wdl))
+            f_env.write("export MAIN_WDL={}\n".format(shlex.quote(app.main_wdl)))
             f_env.write("export WORKFLOW_ENGINE={}\n".format(app.workflow_engine))
             f_env.write("export RUN_ARGS={}\n".format(app.run_args))
-            f_env.write("export WDL_FILES=\"{}\"\n".format(' '.join(app.other_wdl_files.split(','))))
+            f_env.write("export WDL_FILES={}\n".format(shlex.quote(encode_workflow_files(app.other_wdl_files))))
         elif language == 'snakemake':
             f_env.write("export SNAKEMAKE_URL={}\n".format(app.snakemake_url))
-            f_env.write("export MAIN_SNAKEMAKE={}\n".format(app.main_snakemake))
-            f_env.write("export SNAKEMAKE_FILES=\"{}\"\n".format(' '.join(app.other_snakemake_files.split(','))))
+            f_env.write("export MAIN_SNAKEMAKE={}\n".format(shlex.quote(app.main_snakemake)))
+            f_env.write("export SNAKEMAKE_FILES={}\n".format(
+                shlex.quote(encode_workflow_files(app.other_snakemake_files))))
             f_env.write("export COMMAND=\"{}\"\n".format(app.command.replace("\"", "\\\"")))
             f_env.write("export CONTAINER_IMAGE={}\n".format(app.container_image))
         elif language == 'shell':
@@ -215,8 +236,8 @@ def create_env_def_file(env_filename, runjson, language):
             f_env.write("export CONTAINER_IMAGE={}\n".format(app.container_image))
         else:  # cwl
             f_env.write("export CWL_URL={}\n".format(app.cwl_url))
-            f_env.write("export MAIN_CWL={}\n".format(app.main_cwl))
-            f_env.write("export CWL_FILES=\"{}\"\n".format(' '.join(app.other_cwl_files.split(','))))
+            f_env.write("export MAIN_CWL={}\n".format(shlex.quote(app.main_cwl)))
+            f_env.write("export CWL_FILES={}\n".format(shlex.quote(encode_workflow_files(app.other_cwl_files))))
             f_env.write("export RUN_ARGS={}\n".format(app.run_args))
         # other env variables
         env_preserv_str = ''
@@ -249,13 +270,7 @@ def download_workflow():
         main_wf = os.environ.get('MAIN_CWL', '')
         wf_files = os.environ.get('CWL_FILES', '')
         wf_url = os.environ.get('CWL_URL')
-    # turn into a list
-    if not wf_files:
-        wf_files = []
-    elif ' ' in wf_files:
-        wf_files = wf_files.split(' ')
-    else:
-        wf_files = [wf_files]
+    wf_files = decode_workflow_files(wf_files)
     wf_files.append(main_wf)
     wf_url = wf_url.rstrip('/')
 

--- a/tests/awsf3/test_utils.py
+++ b/tests/awsf3/test_utils.py
@@ -2,9 +2,12 @@ import os
 import pytest
 import json
 import boto3
+import subprocess
 from datetime import datetime
 from awsf3.utils import (
     create_env_def_file,
+    decode_workflow_files,
+    download_workflow,
     create_mount_command_list,
     create_download_command_list,
     create_download_cmd,
@@ -54,7 +57,7 @@ def test_create_env_def_file_cwl():
     right_content = ('export LANGUAGE=cwl_v1\n'
                      'export CWL_URL=someurl\n'
                      'export MAIN_CWL=somecwl\n'
-                     'export CWL_FILES="othercwl1 othercwl2"\n'
+                     'export CWL_FILES=\'json:["othercwl1", "othercwl2"]\'\n'
                      'export RUN_ARGS=\n'
                      'export SOME_ENV=1234\n'
                      'export PRESERVED_ENV_OPTION="--preserve-environment SOME_ENV "\n'
@@ -89,7 +92,7 @@ def test_create_env_def_file_wdl_v1():
                      'export MAIN_WDL=somewdl\n'
                      'export WORKFLOW_ENGINE=cromwell\n'
                      'export RUN_ARGS=\n'
-                     'export WDL_FILES="otherwdl1 otherwdl2"\n'
+                     'export WDL_FILES=\'json:["otherwdl1", "otherwdl2"]\'\n'
                      'export PRESERVED_ENV_OPTION=""\n'
                      'export DOCKER_ENV_OPTION=""\n')
 
@@ -122,7 +125,7 @@ def test_create_env_def_file_wdl_draft2():
                      'export MAIN_WDL=somewdl\n'
                      'export WORKFLOW_ENGINE=cromwell\n'
                      'export RUN_ARGS=\n'
-                     'export WDL_FILES="otherwdl1 otherwdl2"\n'
+                     'export WDL_FILES=\'json:["otherwdl1", "otherwdl2"]\'\n'
                      'export PRESERVED_ENV_OPTION=""\n'
                      'export DOCKER_ENV_OPTION=""\n')
 
@@ -155,7 +158,7 @@ def test_create_env_def_file_wdl():
                      'export MAIN_WDL=somewdl\n'
                      'export WORKFLOW_ENGINE=cromwell\n'
                      'export RUN_ARGS=\n'
-                     'export WDL_FILES="otherwdl1 otherwdl2"\n'
+                     'export WDL_FILES=\'json:["otherwdl1", "otherwdl2"]\'\n'
                      'export PRESERVED_ENV_OPTION=""\n'
                      'export DOCKER_ENV_OPTION=""\n')
 
@@ -274,7 +277,7 @@ def test_create_env_def_file_snakemake():
     right_content = ('export LANGUAGE=snakemake\n'
                      'export SNAKEMAKE_URL=someurl\n'
                      'export MAIN_SNAKEMAKE=somesnakemake\n'
-                     'export SNAKEMAKE_FILES="othersnakemake1 othersnakemake2"\n'
+                     'export SNAKEMAKE_FILES=\'json:["othersnakemake1", "othersnakemake2"]\'\n'
                      'export COMMAND="com1;com2"\n'
                      'export CONTAINER_IMAGE=someimage\n'
                      'export PRESERVED_ENV_OPTION=""\n'
@@ -282,6 +285,69 @@ def test_create_env_def_file_snakemake():
 
     assert envfile_content == right_content
     os.remove(envfilename)
+
+
+def test_create_env_def_file_snakemake_with_spaces(tmp_path):
+    """Workflow filenames containing spaces survive shell evaluation."""
+    envfilename = tmp_path / 'env'
+    runjson_dict = {'Job': {'App': {'language': 'snakemake',
+                                    'command': 'snakemake',
+                                    'container_image': 'someimage',
+                                    'snakemake_url': 's3://somebucket/workflow',
+                                    'main_snakemake': 'Snake File',
+                                    'other_snakemake_files':
+                                        'rules/base.smk,jnotebooks/Read Lengths-Copy2.ipynb'},
+                            'Input': {},
+                            'Output': {'output_bucket_directory': 'somebucket'},
+                            'JOBID': 'somejobid'},
+                    'config': {'log_bucket': 'somebucket'}}
+    runjson = AwsemRunJson(**runjson_dict)
+
+    create_env_def_file(envfilename, runjson, 'snakemake')
+
+    result = subprocess.run(
+        ['sh', '-c', '. "$1"; printf "%s\n%s" "$MAIN_SNAKEMAKE" "$SNAKEMAKE_FILES"',
+         'sh', str(envfilename)],
+        check=True,
+        capture_output=True,
+        text=True
+    )
+    assert result.stdout.splitlines() == [
+        'Snake File',
+        'json:["rules/base.smk", "jnotebooks/Read Lengths-Copy2.ipynb"]'
+    ]
+
+
+def test_download_workflow_with_spaces(tmp_path, mocker, monkeypatch):
+    """Workflow filenames containing spaces are passed to S3 intact."""
+    monkeypatch.setenv('LANGUAGE', 'snakemake')
+    monkeypatch.setenv('LOCAL_WFDIR', str(tmp_path))
+    monkeypatch.setenv('MAIN_SNAKEMAKE', 'Snake File')
+    monkeypatch.setenv(
+        'SNAKEMAKE_FILES',
+        'json:["rules/base.smk", "jnotebooks/Read Lengths-Copy2.ipynb"]'
+    )
+    monkeypatch.setenv('SNAKEMAKE_URL', 's3://somebucket/workflow')
+    s3 = mocker.patch('awsf3.utils.boto3.client').return_value
+
+    download_workflow()
+
+    assert s3.download_file.call_args_list == [
+        mocker.call(Bucket='somebucket', Key='workflow/rules/base.smk',
+                    Filename=str(tmp_path / 'rules/base.smk')),
+        mocker.call(Bucket='somebucket', Key='workflow/jnotebooks/Read Lengths-Copy2.ipynb',
+                    Filename=str(tmp_path / 'jnotebooks/Read Lengths-Copy2.ipynb')),
+        mocker.call(Bucket='somebucket', Key='workflow/Snake File',
+                    Filename=str(tmp_path / 'Snake File'))
+    ]
+
+
+def test_decode_workflow_files_legacy_format():
+    """Workers can still read environment files created before this fix."""
+    assert decode_workflow_files('rules/base.smk config/defaults.yml') == [
+        'rules/base.smk',
+        'config/defaults.yml'
+    ]
 
 
 def test_create_mount_command_list():

--- a/tests/awsf3/test_utils.py
+++ b/tests/awsf3/test_utils.py
@@ -8,6 +8,7 @@ from awsf3.utils import (
     create_env_def_file,
     decode_workflow_files,
     download_workflow,
+    encode_workflow_files,
     create_mount_command_list,
     create_download_command_list,
     create_download_cmd,
@@ -344,10 +345,17 @@ def test_download_workflow_with_spaces(tmp_path, mocker, monkeypatch):
 
 def test_decode_workflow_files_legacy_format():
     """Workers can still read environment files created before this fix."""
-    assert decode_workflow_files('rules/base.smk config/defaults.yml') == [
+    assert decode_workflow_files('  rules/base.smk   config/defaults.yml  ') == [
         'rules/base.smk',
         'config/defaults.yml'
     ]
+
+
+def test_encode_workflow_files_ignores_separator_whitespace():
+    """Whitespace around comma separators does not become part of a filename."""
+    assert encode_workflow_files(' rules/base.smk, ,config/defaults.yml,') == (
+        'json:["rules/base.smk", "config/defaults.yml"]'
+    )
 
 
 def test_create_mount_command_list():


### PR DESCRIPTION
## Summary

- serialize workflow child filenames as a JSON list before storing them in the worker environment file
- shell-quote main workflow filenames so spaces are preserved there as well
- retain support for legacy space-delimited worker environment values
- add regression coverage for environment-file evaluation and the resulting S3 download keys

## Root cause

`create_env_def_file` converted the comma-delimited child filename list into a space-delimited string. `download_workflow` then split that value on spaces, so a filename such as `jnotebooks/Read Lengths-Copy2.ipynb` became two unrelated S3 keys.

The new marked JSON representation keeps filename boundaries unambiguous for CWL, WDL, and Snakemake workflows. Existing worker environment files continue to use the legacy decoding path.

## Validation

- `pytest -q tests/awsf3/test_utils.py -k 'create_env_def_file or download_workflow_with_spaces or decode_workflow_files_legacy_format'` (11 passed)
- `pytest -q tests/awsf3 -k 'not upload'` (68 passed, 18 AWS upload tests deselected)
- `python -m compileall -q awsf3 tests/awsf3/test_utils.py`

Closes #326
